### PR TITLE
fix unity version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.6",
   "displayName": "MobiledgeX",
   "description": "The MobiledgeX Unity SDK enables an application to register and then locate the nearest edge cloudlet backend server for use. The SDK also allows verification of a device's location for all location-specific tasks. Because these APIs involve networking, most functions will run asynchronously, and in a background thread.",
-  "unity": "2019",
+  "unity": "2019.1",
   "keywords": [
     "mobiledgex",
     "edge",

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 174260abd2a0d47eb8788a499e843a49
+guid: fe5a90d621aae460e8e8c8163703e1f2
 PackageManifestImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
"The expected format is “<MAJOR>.<MINOR>” (for example, 2018.3)."