### PR TITLE
remove cell id crashing code

### DIFF
--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -56,7 +56,7 @@ namespace MobiledgeX
         return;
       }
 
-      if (sdkVersion >= 17) {
+      /*if (sdkVersion >= 17) {
         cellInfoLte = PlatformIntegrationUtil.GetAndroidJavaObject("android.telephony.CellInfoLte");
         cellInfoLteString = cellInfoLte != null ? PlatformIntegrationUtil.GetSimpleName(cellInfoLte) : "";
 
@@ -81,7 +81,7 @@ namespace MobiledgeX
       {
         cellInfoNr = PlatformIntegrationUtil.GetAndroidJavaObject("android.telephony.CellInfoNr");
         cellInfoNrString = cellInfoNr != null ? PlatformIntegrationUtil.GetSimpleName(cellInfoNr) : "";
-      }
+      }*/
     }
 
     public int getAndroidSDKVers()
@@ -314,19 +314,7 @@ namespace MobiledgeX
 
     public ulong GetCellID()
     {
-      ulong cellID = 0;
-
-      List<KeyValuePair<String, ulong>> cellInfoList = GetCellInfoList();
-
-      if (cellInfoList == null || cellInfoList.Count == 0)
-      {
-        Debug.Log("no cellID");
-        return cellID;
-      }
-
-      KeyValuePair<String, ulong> pair = cellInfoList[0]; // grab first value
-
-      return pair.Value;
+      return 0;
     }
 
 #elif UNITY_IOS

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -58,7 +58,7 @@ namespace MobiledgeX
 
       /*
        * The following code is commented out to prevent Android JNI blacklist crashes.
-       * As of Android API 28, CellInfo interfaces and class reflection are not allowed.
+       * As of Android API 28, CellInfo interfaces and class reflection through JNI are not allowed.
        * (https://developer.android.com/distribute/best-practices/develop/restrictions-non-sdk-interfaces)
        * The following code can be used with older Android API versions.
        */

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -56,6 +56,13 @@ namespace MobiledgeX
         return;
       }
 
+      /*
+       * The following code is commented out to prevent Android JNI blacklist crashes.
+       * As of Android API 28, CellInfo interfaces and class reflection are not allowed.
+       * (https://developer.android.com/distribute/best-practices/develop/restrictions-non-sdk-interfaces)
+       * The following code can be used with older Android API versions.
+       */
+
       /*if (sdkVersion >= 17) {
         cellInfoLte = PlatformIntegrationUtil.GetAndroidJavaObject("android.telephony.CellInfoLte");
         cellInfoLteString = cellInfoLte != null ? PlatformIntegrationUtil.GetSimpleName(cellInfoLte) : "";

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -314,6 +314,19 @@ namespace MobiledgeX
 
     public ulong GetCellID()
     {
+      /*ulong cellID = 0;
+
+      List<KeyValuePair<String, ulong>> cellInfoList = GetCellInfoList();
+
+      if (cellInfoList == null || cellInfoList.Count == 0)
+      {
+        Debug.Log("no cellID");
+        return cellID;
+      }
+
+      KeyValuePair<String, ulong> pair = cellInfoList[0]; // grab first value
+
+      return pair.Value;*/
       return 0;
     }
 


### PR DESCRIPTION
Did a quick look over JNI classes that we use and it looks like only CellInfo information is blacklisted. 

Leaving this commented out instead of removing it entirely, unless there are objections.