### PR TITLE
EDGECLOUD-2903: Unity SDK - Integration script: Call to VerifyLocation() is failing

### DIFF
--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -88,11 +88,11 @@ namespace MobiledgeX
         /// Gets the location from the cellular device, Location is needed for Finding Cloudlet and Location Verification
         /// </summary>
         /// <returns></returns>
-        public async Task<Loc> GetLocationFromDevice()
+        public Loc GetLocationFromDevice()
         {
             // Location is ephemeral, so retrieve a new location from the platform. May return 0,0 which is
             // technically valid, though less likely real, as of writing.
-            Loc loc = await LocationService.RetrieveLocation();
+            Loc loc = LocationService.RetrieveLocation();
             // If in UnityEditor, 0f and 0f are hard zeros as there is no location service.
             if (loc.longitude == 0f && loc.latitude == 0f)
             {
@@ -122,7 +122,7 @@ namespace MobiledgeX
 
         public async Task<FindCloudletReply> FindCloudlet()
         {
-            location = await GetLocationFromDevice();
+            location = GetLocationFromDevice();
             UpdateCarrierName();
 
             FindCloudletRequest req = me.CreateFindCloudletRequest(location, carrierName);
@@ -143,7 +143,7 @@ namespace MobiledgeX
                 throw new Exception("Device is not edge enabled. Please switch to cellular connection or use server in public cloud");
             }
 
-            location = await GetLocationFromDevice();
+            location = GetLocationFromDevice();
             UpdateCarrierName();
 
             if (port == 0)
@@ -190,7 +190,7 @@ namespace MobiledgeX
         /// <returns></returns>
         public async Task<String> GetURI(LProto protocol = LProto.L_PROTO_TCP, int port = 0)
         {
-            location = await GetLocationFromDevice();
+            location = GetLocationFromDevice();
             UpdateCarrierName();
 
             string uri = "";
@@ -278,7 +278,7 @@ namespace MobiledgeX
         /// <returns></returns>
         public async Task<bool> VerifyLocation()
         {
-            location = await GetLocationFromDevice();
+            location = GetLocationFromDevice();
             UpdateCarrierName();
 
             VerifyLocationRequest req = me.CreateVerifyLocationRequest(location, carrierName);

--- a/Tests/Runtime/MobiledgeX_RuntimeTests.cs
+++ b/Tests/Runtime/MobiledgeX_RuntimeTests.cs
@@ -34,7 +34,7 @@ namespace MobiledgeX
             }
             else
             {
-                settings = Resources.Load<MobiledgeXSettings>("MobiledgeXSettings");
+                // settings = Resources.Load<MobiledgeXSettings>("MobiledgeXSettings");
                 integration = new MobiledgeXIntegration();
                 testLocation = new Loc
                 {
@@ -48,9 +48,9 @@ namespace MobiledgeX
         public void Clean()
         {
             integration = null;
-            settings.orgName = "";
-            settings.appName = "";
-            settings.appVers = "";
+            MobiledgeXIntegration.orgName = "";
+            MobiledgeXIntegration.appName = "";
+            MobiledgeXIntegration.appVers = "";
         }
 
         #endregion
@@ -61,24 +61,57 @@ namespace MobiledgeX
         [TestCase("MobiledgeX", "MobiledgeX SDK Demo", "2.0")]
         public void RegisterClient(string orgName, string appName, string appVers)
         {
-            settings.orgName = orgName;
-            settings.appName = appName;
-            settings.appVers = appVers;
+            MobiledgeXIntegration.orgName = orgName;
+            MobiledgeXIntegration.appName = appName;
+            MobiledgeXIntegration.appVers = appVers;
             var task = Task.Run(async () =>
             {
                 return await RegisterHelper();
             });
 
+            Debug.Log("result of registerClient is " + task.Result);
             Assert.True(task.Result);
         }
 
         [Test]
         [TestCase("MobiledgeX", "MobiledgeX SDK Demo", "2.0")]
+        public void FindCloudlet(string orgName, string appName, string appVers)
+		{
+            MobiledgeXIntegration.orgName = orgName;
+            MobiledgeXIntegration.appName = appName;
+            MobiledgeXIntegration.appVers = appVers;
+            var task = Task.Run(async () =>
+            {
+                bool registered = await RegisterHelper();
+                Assert.True(registered, "Unable to register");
+                return await FindCloudletHelper();
+            });
+
+            Debug.Log("findCloudletreply status is " + task.Result.status);
+            Assert.True(task.Result != null);
+		}
+
+        [Test]
+        [TestCase("MobiledgeX", "MobiledgeX SDK Demo", "2.0")]
+        public void VerifyLocation(string orgName, string appName, string appVers)
+		{
+            var task = Task.Run(async () =>
+            {
+                bool registered = await RegisterHelper();
+                Assert.True(registered, "Unable to register");
+                return await VerifyLocationHelper();
+            });
+
+            Assert.True(task.Result);
+		}
+
+        [Test]
+        [TestCase("MobiledgeX", "MobiledgeX SDK Demo", "2.0")]
         public void GetRestURI(string orgName, string appName, string appVers)
         {
-            settings.orgName = orgName;
-            settings.appName = appName;
-            settings.appVers = appVers;
+            MobiledgeXIntegration.orgName = orgName;
+            MobiledgeXIntegration.appName = appName;
+            MobiledgeXIntegration.appVers = appVers;
             var task = Task.Run(async () =>
             {
                 return await RegisterAndFindCloudletHelper( orgName, appName, appVers);
@@ -91,9 +124,9 @@ namespace MobiledgeX
         [TestCase("WrongCredentials", "WrongAppName", "WrongAppVersion")]
         public void GetRestURIException(string orgName, string appName, string appVers)
         {
-            settings.orgName = orgName;
-            settings.appName = appName;
-            settings.appVers = appVers;
+            MobiledgeXIntegration.orgName = orgName;
+            MobiledgeXIntegration.appName = appName;
+            MobiledgeXIntegration.appVers = appVers;
             try
             {
                 GetRestURI(orgName, appName, appVers);
@@ -116,12 +149,12 @@ namespace MobiledgeX
         }
 
         [Test]
-        [TestCase("MobiledgeX", "PingPong", "2020-02-03")]
+        [TestCase("MobiledgeX", "PingPong", "2.0")]
         public void WebSocketTest(string orgName, string appName, string appVers)
         {
-            settings.orgName = orgName;
-            settings.appName = appName;
-            settings.appVers = appVers;
+            MobiledgeXIntegration.orgName = orgName;
+            MobiledgeXIntegration.appName = appName;
+            MobiledgeXIntegration.appVers = appVers;
             var task = Task.Run(async () =>
             {
                 return await WebSocketTestHelper(orgName, appName, appVers);
@@ -135,9 +168,9 @@ namespace MobiledgeX
         [TestCase("WrongCredentials", "WrongAppName", "WrongAppVersion")]
         public void WebSocketTestExpectedException(string orgName, string appName, string appVers)
         {
-            settings.orgName = orgName;
-            settings.appName = appName;
-            settings.appVers = appVers;
+            MobiledgeXIntegration.orgName = orgName;
+            MobiledgeXIntegration.appName = appName;
+            MobiledgeXIntegration.appVers = appVers;
             try
             {
                 WebSocketTest(orgName, appName, appVers);
@@ -170,6 +203,22 @@ namespace MobiledgeX
 
             return check;
         }
+
+        public async Task<FindCloudletReply> FindCloudletHelper()
+		{
+            FindCloudletReply reply = await integration.FindCloudlet();
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+            return reply;
+		}
+
+        public async Task<bool> VerifyLocationHelper()
+		{
+            bool verified = await integration.VerifyLocation();
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+            return verified;
+		}
 
         public async Task<string> RegisterAndFindCloudletHelper(string orgName, string appName, string appVers)
         {


### PR DESCRIPTION
1) Took Garner's MobiledgeXLocationService from Companion app and copied into LocationService.cs. isEnabledByUser is now checked on the main thread and LocationInfo is updated on each Update() (when LocationServiceStatus is running). @LeonAdams This should fix the issues you were seeing in your tests. 

(@lgarner Just so that I'm clear, the reason isEnabledByUser has to be checked on the main thread is: It is a property, which can hide function calls and all UnityEngine functions must be called from the main thread (for some reason...))

2) Added Unit tests for FindCloudlet and VerifyLocation 

3) Changing settings.orgName does not have any affect on the subsequent API calls. We have to change MobiledgeXIntegration.orgName in order to change the parameters for Register(), FindCloudlet(), etc.

