### PR TITLE
Fix Unity SDK for geolocated wifi.dme DNS

### DIFF
--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -435,12 +435,12 @@ namespace MobiledgeX
     // Implement CarrierInfo
     public string GetCurrentCarrierName()
     {
-      return "wifi";
+      return "";
     }
 
     public string GetMccMnc()
     {
-      return "26201";
+      return "";
     }
 
     public ulong GetCellID()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mobiledgex.sdk",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "displayName": "MobiledgeX",
   "description": "The MobiledgeX Unity SDK enables an application to register and then locate the nearest edge cloudlet backend server for use. The SDK also allows verification of a device's location for all location-specific tasks. Because these APIs involve networking, most functions will run asynchronously, and in a background thread.",
   "unity": "2019.1",


### PR DESCRIPTION
Global DME usage for Editor should be referencing nothing of the original TDG DME. Unity SDK works (again).