### PR TITLE
link.xml Update to support .NET 4.x

### DIFF
--- a/link.xml
+++ b/link.xml
@@ -1,3 +1,4 @@
 <linker>
     <assembly fullname="System.Runtime.Serialization" preserve="all"/>
+    <assembly fullname="System.Runtime.Serialization.Json" preserve="all"/>
 </linker>


### PR DESCRIPTION
Garner Solution to support .NET 4.X ([ApiCompatibilityLevel](https://docs.unity3d.com/ScriptReference/ApiCompatibilityLevel.html))
This solution will preserve the two assemblies from [stripping](https://docs.unity3d.com/2018.3/Documentation/Manual/ManagedCodeStripping.html) during the build
([link](https://docs.microsoft.com/en-us/visualstudio/cross-platform/unity-scripting-upgrade?view=vs-2019))

