### PR TITLE
IsRoaming function for IOS

### DIFF
--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -258,7 +258,7 @@ char* _getISOCountryCodeFromCarrier()
 
     if (@available(iOS 12.1, *))
     {
-        carrier = [networkState.lastCarrier];
+        carrier = networkState.lastCarrier;
     }
     else
     {
@@ -266,9 +266,7 @@ char* _getISOCountryCodeFromCarrier()
         carrier = [netinfo subscriberCellularProvider]; // s for dual SIM?
         NSLog(@"Carrier Name: %@", [carrier carrierName]);
         // Ref counted.
-
-        nsstr = [carrier carrierName];
     }
     NSLog(@"ISO Country code: %@", carrier.isoCountryCode);
-    return convertToCStr(carrier.isoCountryCode);
+    return convertToCStr([carrier.isoCountryCode UTF8String]);
 }

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -260,7 +260,6 @@ void _convertGPSToISOCountryCode(double longitude, double latitude)
          if(placemarks && placemarks.count > 0)
          {
              CLPlacemark *placemark= [placemarks objectAtIndex:0];
-
              isoCountryCode = [placemark ISOcountryCode];
          }
      }];

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -253,5 +253,22 @@ char* _getISOCountryCodeFromGPS()
 
 char* _getISOCountryCodeFromCarrier()
 {
-    return convertToCStr("carrier");
+    _ensureMatchingEnginePlatformIntegration();
+    CTCarrier *carrier;
+
+    if (@available(iOS 12.1, *))
+    {
+        carrier = [networkState.lastCarrier];
+    }
+    else
+    {
+        CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
+        carrier = [netinfo subscriberCellularProvider]; // s for dual SIM?
+        NSLog(@"Carrier Name: %@", [carrier carrierName]);
+        // Ref counted.
+
+        nsstr = [carrier carrierName];
+    }
+    NSLog(@"ISO Country code: %@", carrier.isoCountryCode);
+    return convertToCStr(carrier.isoCountryCode);
 }

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -243,5 +243,15 @@ char* _getUniqueID()
 
 char* _getUniqueIDType()
 {
-    return "";
+    return convertToCStr("");
+}
+
+char* _getISOCountryCodeFromGPS()
+{
+    return convertToCStr("gps");
+}
+
+char* _getISOCountryCodeFromCarrier()
+{
+    return convertToCStr("carrier");
 }

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -250,6 +250,8 @@ char* _getUniqueIDType()
 
 void _convertGPSToISOCountryCode(double longitude, double latitude)
 {
+    // reset isoCountryCode, so we don't get previous country code
+    isoCountryCode = NULL;
     CLLocation *location = [[CLLocation alloc] initWithLatitude:latitude longitude:longitude];
     CLGeocoder *geocoder = [[CLGeocoder alloc] init];
     [geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -260,14 +260,14 @@ void _convertGPSToISOCountryCode(double longitude, double latitude)
              CLPlacemark *placemark= [placemarks objectAtIndex:0];
 
              isoCountryCode = [placemark ISOcountryCode];
-             NSLog(@"ISO Country code in completion handler: %@", isoCountryCode);
          }
      }];
 }
 
 char* _getISOCountryCodeFromGPS()
 {
-    return convertToCStr([isoCountryCode UTF8String]);
+    NSString* capitalizedISOCC = [isoCountryCode uppercaseString];
+    return convertToCStr([capitalizedISOCC UTF8String]);
 }
 
 char* _getISOCountryCodeFromCarrier()
@@ -282,13 +282,8 @@ char* _getISOCountryCodeFromCarrier()
     else
     {
         CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
-        carrier = [netinfo subscriberCellularProvider]; // s for dual SIM?
+        carrier = [netinfo subscriberCellularProvider];
     }
-    NSLog(@"ISO Country code: %@", carrier.isoCountryCode);
-    return convertToCStr([carrier.isoCountryCode UTF8String]);
-}
-
-char* capitalizeString(char* str)
-{
-    return convertToCStr(str);
+    NSString* capitalizedISOCC = [carrier.isoCountryCode uppercaseString];
+    return convertToCStr([capitalizedISOCC UTF8String]);
 }

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -375,6 +375,12 @@ namespace MobiledgeX
     [DllImport("__Internal")]
     private static extern int _getCellID();
 
+    [DllImport("__Internal")]
+    private static extern string _getISOCountryCodeFromGPS();
+
+    [DllImport("__Internal")]
+    private static extern string _getISOCountryCodeFromCarrier();
+
     public string GetCurrentCarrierName()
     {
       string networkOperatorName = "";
@@ -403,6 +409,33 @@ namespace MobiledgeX
         cellID = _getCellID();
       }
       return (ulong)cellID;
+    }
+
+    public bool IsRoaming()
+    {
+      Debug.Log("iso from country is " + GetISOCountryCodeFromGPS());
+      Debug.Log("iso from carrier is " + GetISOCountryCodeFromCarrier());
+      return true;
+    }
+
+    private string GetISOCountryCodeFromGPS()
+    {
+      string isoCC = null;
+      if (Application.platform == RuntimePlatform.IPhonePlayer)
+      {
+        isoCC = _getISOCountryCodeFromGPS();
+      }
+      return isoCC;
+    }
+
+    private string GetISOCountryCodeFromCarrier()
+    {
+      string isoCC = null;
+      if (Application.platform == RuntimePlatform.IPhonePlayer)
+      {
+        isoCC = _getISOCountryCodeFromCarrier();
+      }
+      return isoCC;
     }
 
 #else

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -459,7 +459,7 @@ namespace MobiledgeX
         }
         Debug.Log("ISO country code from carrier is " + isoCCFromCarrier);
 
-        return isoCCFromGPS == isoCCFromCarrier;
+        return isoCCFromGPS != isoCCFromCarrier;
       }
 
       // If in UnityEditor, return not roaming

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -433,23 +433,29 @@ namespace MobiledgeX
       if (Application.platform == RuntimePlatform.IPhonePlayer)
       {  
         Task<string> task = ConvertGPSToISOCountryCode(longitude, latitude);
-        if (!task.Wait(5000))
+        string isoCCFromGPS = null;
+        if (await Task.WhenAny(task, Task.Delay(5000)) == task)
         {
-            throw new CarrierInfoException("Timeout: unable to get ISO country code from gps");
+          isoCCFromGPS = await task; 
         }
-        string isoCCFromGPS = await task;
+        else
+        {
+          // Timeout
+          throw new CarrierInfoException("Timeout: unable to get ISO country code from gps");
+        }
+
         if (isoCCFromGPS == null)
         {
-            Debug.LogError("Unable to get ISO country code from gps");
-            throw new CarrierInfoException("Unable to get ISO country code from gps");
+          Debug.LogError("Unable to get ISO country code from gps");
+          throw new CarrierInfoException("Unable to get ISO country code from gps");
         }
         Debug.Log("ISO country code from gps location is " + isoCCFromGPS);
 
         string isoCCFromCarrier = GetISOCountryCodeFromCarrier();
         if (isoCCFromCarrier == null)
         {
-            Debug.LogError("Unable to get ISO country code from carrier");
-            throw new CarrierInfoException("Unable to get ISO country code from carrier");
+          Debug.LogError("Unable to get ISO country code from carrier");
+          throw new CarrierInfoException("Unable to get ISO country code from carrier");
         }
         Debug.Log("ISO country code from carrier is " + isoCCFromCarrier);
 
@@ -472,7 +478,7 @@ namespace MobiledgeX
             isoCC = GetISOCountryCodeFromGPS();
           }
           return isoCC;
-         });
+         }).ConfigureAwait(false);
       }
 
       return null;

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -443,7 +443,6 @@ namespace MobiledgeX
           // Timeout
           throw new CarrierInfoException("Timeout: unable to get ISO country code from gps");
         }
-
         if (isoCCFromGPS == null)
         {
           Debug.LogError("Unable to get ISO country code from gps");

--- a/Runtime/Scripts/Example.cs
+++ b/Runtime/Scripts/Example.cs
@@ -64,27 +64,18 @@ public class Example : MonoBehaviour
     async Task RestExample()
     {
         MobiledgeXIntegration mxi = new MobiledgeXIntegration();
-        CarrierInfoClass ci = new CarrierInfoClass();
 
+#if UNITY_IOS
         try
         {
-            bool isRoaming = await ci.IsRoaming(-121.243, 37.443);
-            Debug.Log("isRoaming in US: " + isRoaming);
+            bool isRoaming = await mxi.IsRoaming();
+            Debug.Log("isRoaming " + isRoaming);
         }
         catch (CarrierInfoException cie)
         {
             Debug.Log("carrierinfo exception in US: " + cie.Message);
         }
-
-        try
-        {
-            bool isRoaming = await ci.IsRoaming(0.0, -27.0);
-            Debug.Log("isRoaming in Ocean: " + isRoaming);
-        }
-        catch (CarrierInfoException cie)
-        {
-            Debug.Log("carrierinfo exception in Ocean: " + cie.Message);
-        }
+#endif
 
 #if UNITY_EDITOR
         mxi.UseWifiOnly(true);

--- a/Runtime/Scripts/Example.cs
+++ b/Runtime/Scripts/Example.cs
@@ -64,6 +64,8 @@ public class Example : MonoBehaviour
     async Task RestExample()
     {
         MobiledgeXIntegration mxi = new MobiledgeXIntegration();
+        CarrierInfoClass ci = new CarrierInfoClass();
+        await ci.IsRoaming(-121.243, 37.443);
 
 #if UNITY_EDITOR
         mxi.UseWifiOnly(true);

--- a/Runtime/Scripts/Example.cs
+++ b/Runtime/Scripts/Example.cs
@@ -65,7 +65,26 @@ public class Example : MonoBehaviour
     {
         MobiledgeXIntegration mxi = new MobiledgeXIntegration();
         CarrierInfoClass ci = new CarrierInfoClass();
-        await ci.IsRoaming(-121.243, 37.443);
+
+        try
+        {
+            bool isRoaming = await ci.IsRoaming(-121.243, 37.443);
+            Debug.Log("ISO:: isRoaming in US: " + isRoaming);
+        }
+        catch (CarrierInfoException cie)
+		{
+            Debug.Log("ISO:: carrierinfo exception: " + cie.Message);
+		}
+
+        try
+        {
+            bool isRoaming = await ci.IsRoaming(0.0, -27.0);
+            Debug.Log("ISO:: isRoaming in Ocean: " + isRoaming);
+        }
+        catch (CarrierInfoException cie)
+		{
+            Debug.Log("ISO:: ocean carrierinfo exception: " + cie.Message);
+		}
 
 #if UNITY_EDITOR
         mxi.UseWifiOnly(true);

--- a/Runtime/Scripts/Example.cs
+++ b/Runtime/Scripts/Example.cs
@@ -69,22 +69,22 @@ public class Example : MonoBehaviour
         try
         {
             bool isRoaming = await ci.IsRoaming(-121.243, 37.443);
-            Debug.Log("ISO:: isRoaming in US: " + isRoaming);
+            Debug.Log("isRoaming in US: " + isRoaming);
         }
         catch (CarrierInfoException cie)
-		{
-            Debug.Log("ISO:: carrierinfo exception: " + cie.Message);
-		}
+        {
+            Debug.Log("carrierinfo exception in US: " + cie.Message);
+        }
 
         try
         {
             bool isRoaming = await ci.IsRoaming(0.0, -27.0);
-            Debug.Log("ISO:: isRoaming in Ocean: " + isRoaming);
+            Debug.Log("isRoaming in Ocean: " + isRoaming);
         }
         catch (CarrierInfoException cie)
-		{
-            Debug.Log("ISO:: ocean carrierinfo exception: " + cie.Message);
-		}
+        {
+            Debug.Log("carrierinfo exception in Ocean: " + cie.Message);
+        }
 
 #if UNITY_EDITOR
         mxi.UseWifiOnly(true);

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -83,6 +83,7 @@ namespace MobiledgeX
         AppPort latestAppPort = null;
         AppPort[] latestAppPortList = null;
         Location fallbackLocation = new Location(-121.8863286, 37.3382082);
+        CarrierInfoClass carrierInfoClass = new CarrierInfoClass(); // used for IsRoaming check
 
         /// <summary>
         /// Constructor for MobiledgeXIntegration. This class has functions that wrap DistributedMatchEngine functions for ease of use

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -193,6 +193,18 @@ namespace MobiledgeX
             return false;
         }
 
+#if UNITY_IOS
+        /// <summary>
+        /// Function for IOS that checks if device is in different country from carrier network
+        /// </summary>
+        /// <returns>bool</returns>
+        public async Task<bool> IsRoaming()
+        {
+            location = GetLocationFromDevice();
+            return await carrierInfoClass.IsRoaming(location.longitude, location.latitude);
+        }
+#endif
+
         /// <summary>
         /// Checks whether Edge is Enabled on the device or not, Edge requires connections to run over cellular interface
         /// </summary>


### PR DESCRIPTION
Similar logic to https://github.com/mobiledgex/MatchingEngineSDK/pull/74

1. Added an IsRoaming function to CarrierInfoClass for now (will add to CarrierInfoInterface in C# SDK and add this check to GenerateDMEHost and GetCarrierName if this is approved)
2. Added _getISOCountryCodeFromGPS(), _getISOCountryCodeFromCarrier(), and _convertGPSToISOCountryCode(double longitude, double latitude) functions to PlatformIntegration.m file
- _convertGPSToISOCountryCode(double longitude, double latitude) gets the ISO Country code from gps location asynchronously. Once done, it stores the ISO Country code in an NSString* class variable (isoCountryCode). 
- _getISOCountryCodeFromGPS() will grab that class variable
- _getISOCountryCodeFromCarrier() gets the ISO cc from the carrier (CoreTelephony)
3. Added GetISOCountryCodeFromGPS(), GetISOCountryCodeFromCarrier(), ConvertGPSToISOCountryCode(double longitude, double latitude) to CarrierInfoClass. These correspond to each of the functions in PlatformIntegration.m
- These functions are used by IsRoaming to compare ISO Country Code from gps location with ISO Country Code from the carrier
- ConvertGPSToISOCountryCode(double longitude, double latitude) returns a Task<string>. This task polls the isoCountryCode variable by calling GetISOCountryCodeFromGPS() until it is not null or an empty string.
- GetISOCountryCodeFromGPS() grabs the isoCountryCode variable from PlatformIntegration.m
- GetISOCountryCodeFromCarrier() gets the ISO cc from the carrier
4. Added some sample code to show how to use this IsRoaming function. The first try/catch tests a San Jose GPS location and the second try/catch tests some location in the Atlantic that will not have an ISO country code.