### PR TITLE
EDGECLOUD-2987: IOS SDK: If in roaming mode, use global DME and FindCloudlet Performance Mode.

### DIFF
--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -125,9 +125,8 @@ namespace MobiledgeX
                 return false;
             }
 
-            location = GetLocationFromDevice();
-            UpdateCarrierName();
-            
+            await UpdateLocationAndCarrierInfo();
+
             VerifyLocationRequest req = matchingEngine.CreateVerifyLocationRequest(location, carrierName);
             VerifyLocationReply reply = await matchingEngine.VerifyLocation(req);
 

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -236,7 +236,7 @@ namespace MobiledgeX
             {
                 if (reply.ports.Length > 1)
                 {
-                    throw new Exception("MobiledgeX: Unexpected Port length for MEL mode.");
+                    throw new AppPortException("MobiledgeX: Unexpected Port length for MEL mode.");
                 }
 
                 AppPort appPort = reply.ports[0];


### PR DESCRIPTION
1. Add IsRoaming check before each DME API call. If IOS device is roaming, useWifiOnly mode
2. Converted GetLocationFromDevice to UpdateLocationFromDevice (no return value, just updates location global variable to match UpdateCarrierName function)
3. Wrap UpdateLocationFromDevice, IsRoaming, and UpdateCarrierName into one function: UpdateLocationAndCarrierInfo. 
- This function will be called before each DME API to make sure location is updated, the ios roaming check is called to check if we need to useWifiOnly mode, and carrier name is updated
- RegisterClient requires this call also because we need the Roaming check, which requires location
