### PR TITLE
if roaming check fails, assume not roaming

### DIFF
--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -69,7 +69,14 @@ namespace MobiledgeX
             Debug.Log("MobiledgeX: AppName: " + req.app_name);
             Debug.Log("MobiledgeX: AppVers: " + req.app_vers);
 
-            await UpdateLocationAndCarrierInfo();
+            try
+            {
+                await UpdateLocationAndCarrierInfo();
+            }
+            catch (CarrierInfoException cie)
+            {
+                throw new RegisterClientException(cie.Message);
+            }
 
             RegisterClientReply reply;
             try
@@ -109,7 +116,14 @@ namespace MobiledgeX
                 throw new FindCloudletException("Last RegisterClient was unsuccessful. Call RegisterClient again before FindCloudlet");
             }
 
-            await UpdateLocationAndCarrierInfo();
+            try
+            {
+                await UpdateLocationAndCarrierInfo();
+            }
+            catch (CarrierInfoException cie)
+            {
+                throw new FindCloudletException(cie.Message);
+            }
 
             FindCloudletRequest req = matchingEngine.CreateFindCloudletRequest(location, carrierName);
             FindCloudletReply reply;
@@ -189,6 +203,12 @@ namespace MobiledgeX
         /// <returns>bool</returns>
         public async Task<bool> IsRoaming()
         {
+            if (location.longitude == 0 && location.latitude == 0)
+            {
+                Debug.LogError("Invalid location: (0,0). Please wait for valid location information before checking roaming status.");
+                throw CarrierInfoException("Invalid location: (0,0). Please wait for valid location information before checking roaming status.");
+            }
+
             try
             {
                 return await carrierInfoClass.IsRoaming(location.longitude, location.latitude);

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -203,11 +203,14 @@ namespace MobiledgeX
         /// <returns>bool</returns>
         public async Task<bool> IsRoaming()
         {
+#if !UNITY_EDITOR
+            // 0,0 is fine in Unity Editor
             if (location.longitude == 0 && location.latitude == 0)
             {
                 Debug.LogError("Invalid location: (0,0). Please wait for valid location information before checking roaming status.");
                 throw CarrierInfoException("Invalid location: (0,0). Please wait for valid location information before checking roaming status.");
             }
+#endif
 
             try
             {

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -189,7 +189,15 @@ namespace MobiledgeX
         /// <returns>bool</returns>
         public async Task<bool> IsRoaming()
         {
-            return await carrierInfoClass.IsRoaming(location.longitude, location.latitude);
+            try
+            {
+                return await carrierInfoClass.IsRoaming(location.longitude, location.latitude);
+            }
+            catch (CarrierInfoException cie)
+            {
+                Debug.LogError("Unable to get Roaming status. CarrierInfoException: " + cie.Message + ". Assuming device is not roaming");
+                return false;
+            }
         }
 #endif
 


### PR DESCRIPTION
Wasn't catching the exceptions thrown in IsRoaming. If there is a problem, assume that device is not roaming so that we can continue with DME calls. 