### PR TITLE
EDGECLOUD-3430: Unity SDK - MobiledgeX Integration script errors keeping the MobiledgeX package from being installed 

### DIFF
--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -26,8 +26,9 @@ using System;
             {
                 await mxi.RegisterAndFindCloudlet();
             }
-            catch (DmeDnsException)
+            catch (DmeDnsException dde)
             {
+                Debug.Log("Dme dns Exception: " + dde.Message);
                 mxi.UseWifiOnly(true);
                 await mxi.RegisterAndFindCloudlet();
             }

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -292,7 +292,7 @@ namespace MobiledgeX
                 appPort = latestAppPort;
             }
 
-            return matchingEngine.CreateUrl(latestFindCloudletReply, appPort, port, l7Proto, path);
+            return matchingEngine.CreateUrl(latestFindCloudletReply, appPort, l7Proto, port, path);
         }
 
         /// <summary>

--- a/Runtime/Scripts/PlatformIntegration.cs
+++ b/Runtime/Scripts/PlatformIntegration.cs
@@ -49,6 +49,16 @@ namespace MobiledgeX
           CarrierInfo = new TestCarrierInfoClass();
           UniqueID = new TestUniqueIDClass();
           break;
+        case RuntimePlatform.LinuxPlayer: case RuntimePlatform.LinuxEditor:
+          NetworkInterfaceName = new LinuxNetworkInterfaceName();
+          CarrierInfo = new TestCarrierInfoClass();
+          UniqueID = new TestUniqueIDClass();
+          break;
+        case RuntimePlatform.WindowsPlayer: case RuntimePlatform.WindowsEditor:
+          NetworkInterfaceName = new Windows10NetworkInterfaceName();
+          CarrierInfo = new TestCarrierInfoClass();
+          UniqueID = new TestUniqueIDClass();
+          break;
         default:
           CarrierInfo = new CarrierInfoClass();
           UniqueID = new UniqueIDClass();


### PR DESCRIPTION
1) Switched order of parameters for CreateUrl in C# SDK -> update in Unity SDK
2) Add Unity SDK support for Linux and Windows10