### PR TITLE
Expose Location Parameter for Developers

### DIFF
--- a/Runtime/Scripts/LocationService.cs
+++ b/Runtime/Scripts/LocationService.cs
@@ -30,9 +30,18 @@ namespace MobiledgeX
     {
         private static bool locationPermissionRejected = false;
 
+        [Tooltip("Disable LocationService flow if you will use SetupLocation() to supply your the location on your own")]
+        [SerializeField]
+        bool useLocationServiceFlow = true;
+
+        static Loc locationSupplied;
+
         void Awake()
         {
-            StartCoroutine(LocationServiceFlow());
+            if (useLocationServiceFlow)
+            {
+                StartCoroutine(LocationServiceFlow());
+            }
         }
 
         public static IEnumerator InitalizeLocationService(int maxWait = 20, bool continuousLocationService = false)
@@ -147,9 +156,20 @@ namespace MobiledgeX
             }
         }
 
+        public static void SetupLocation(Loc location)
+        {
+            locationSupplied = location;
+        }
+
         // Retrieve the lastest location, without restarting locationService.
         public static Loc RetrieveLocation()
         {
+            if (Input.location.lastData.Equals(default(LocationInfo))){
+
+                return locationSupplied;
+                
+            }
+
             LocationInfo locationInfo = Input.location.lastData;
             Debug.Log("Location Info: [" + locationInfo.longitude + "," + locationInfo.latitude + "]");
             return ConvertUnityLocationToDMELoc(locationInfo);


### PR DESCRIPTION
https://mobiledgex.atlassian.net/browse/EDGECLOUD-3157

Location is used in **RegisterClient**  (isRoaming check) & **FindCloudlet**

Disable LocationService in the Inspector and use SetupLocation(Loc) before Register&FindCloudlet()
* no need to use LocationService.EnsureLocation if you will use SetupLocation()

<img width="591" alt="Screen Shot 2020-08-31 at 6 12 36 PM" src="https://user-images.githubusercontent.com/24863504/91783585-8fa84900-ebb5-11ea-90e6-a6304cd4bad2.png">
