### PR TITLE
MobiledgeXUDPClient EDGECLOUD-3158

### DIFF
--- a/Runtime/Scripts/MobiledgeXUDPClient.cs
+++ b/Runtime/Scripts/MobiledgeXUDPClient.cs
@@ -1,0 +1,144 @@
+﻿/**
+ * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using System.Linq;
+namespace MobiledgeX
+{
+    // MobiledgeXUDPClient is a UDP Client Implementation offered with MobiledgeX Unity Package
+    // MobiledgeXUDPClient concurrency model supports the use of a single queue for
+    // send, and another queue for recieve. MobiledgeXUDPClient here has 1 independent thread
+    // per send or receive direction of communication.
+    public class MobiledgeXUDPClient : IDisposable
+    {
+        private UdpClient udpClient;
+        private string host;
+        private int port;
+        Thread receiveThread { get; set; }
+        Thread sendThread { get; set; }
+        static UTF8Encoding encoder;
+        public ConcurrentQueue<byte[]> receiveQueue { get; }
+        public BlockingCollection<ArraySegment<byte>> sendQueue { get; }
+        public bool run = true;
+        const int MAXPAYLOADSIZE = 508; // max payload size guaranteed to be deliverable (not guaranteed to be delivered)
+
+        public MobiledgeXUDPClient(string hostName, int sendPort, int receivePort)
+        {
+            try
+            {
+                udpClient = new UdpClient(receivePort);
+                udpClient.DontFragment = true;
+
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Failed to listen for UDP at port " + receivePort + ": " + e.Message);
+                return;
+            }
+
+            host = Dns.GetHostAddresses(hostName)
+                .First(ip => ip.AddressFamily == AddressFamily.InterNetwork
+                || ip.AddressFamily == AddressFamily.InterNetworkV6).ToString();
+            port = sendPort;
+            encoder = new UTF8Encoding();
+            receiveQueue = new ConcurrentQueue<byte[]>();
+            receiveThread = new Thread(RunReceive);
+            receiveThread.Start();
+            sendQueue = new BlockingCollection<ArraySegment<byte>>();
+            sendThread = new Thread(RunSend);
+            sendThread.Start();
+            Connect();
+        }
+
+        public void Connect()
+        {
+            run = true;
+        }
+
+        public void Send(string message)
+        {
+
+            byte[] buffer = encoder.GetBytes(message);
+            if (buffer.Length > MAXPAYLOADSIZE)
+            {
+                Debug.LogError("Max UDP payload size is 508 bytes, trying slicing your message to suit the max payload size");
+                return;
+            }
+            var sendBuf = new ArraySegment<byte>(buffer);
+            sendQueue.Add(sendBuf);
+        }
+
+        public void Send(byte[] buffer)
+        {
+            if (buffer.Length > MAXPAYLOADSIZE)
+            {
+                Debug.LogError("Max UDP payload size is 508 bytes, trying slicing your buffer to suit the max payload size");
+                return;
+            }
+            var sendBuf = new ArraySegment<byte>(buffer);
+            sendQueue.Add(sendBuf);
+        }
+
+        public async void RunSend()
+        {
+            ArraySegment<byte> msg;
+            Debug.Log("RunSend entered.");
+            while (run)
+            {
+                while (!sendQueue.IsCompleted)
+                {
+                    msg = sendQueue.Take();
+                    long count = sendQueue.Count;
+                    Debug.Log("Dequeued this message to send: " + msg + ", queueSize: " + count);
+                    IPEndPoint serverEndpoint = new IPEndPoint(IPAddress.Parse(host), port);
+                    await udpClient.SendAsync(msg.Array, msg.Count, serverEndpoint);
+                }
+            }
+        }
+
+        public async void RunReceive()
+        {
+            while (run)
+            {
+                Debug.Log("Awaiting Receive...");
+                UdpReceiveResult result = await udpClient.ReceiveAsync();
+                if (result != null && result.Buffer.Length > 0)
+                {
+                    receiveQueue.Enqueue(result.Buffer);
+                }
+                else
+                {
+                    Task.Delay(50).Wait();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            run = false;
+            sendThread.Abort();
+            receiveThread.Abort();
+            udpClient.Close();
+        }
+    }
+}

--- a/Runtime/Scripts/MobiledgeXUDPClient.cs
+++ b/Runtime/Scripts/MobiledgeXUDPClient.cs
@@ -52,7 +52,7 @@ namespace MobiledgeX
             }
             catch (Exception e)
             {
-                Debug.LogError("Failed to listen for UDP at port " + receivePort + ": " + e.Message);
+                Debug.LogError("Failed to listen to UDP Messages at port " + receivePort + ": " + e.Message);
                 return;
             }
 
@@ -81,7 +81,7 @@ namespace MobiledgeX
             byte[] buffer = encoder.GetBytes(message);
             if (buffer.Length > MAXPAYLOADSIZE)
             {
-                Debug.LogError("Max UDP payload size is 508 bytes, trying slicing your message to suit the max payload size");
+                Debug.LogError("Max UDP payload size is "+ MAXPAYLOADSIZE + " bytes, try slicing your message to suit the max payload size");
                 return;
             }
             var sendBuf = new ArraySegment<byte>(buffer);
@@ -92,7 +92,7 @@ namespace MobiledgeX
         {
             if (buffer.Length > MAXPAYLOADSIZE)
             {
-                Debug.LogError("Max UDP payload size is 508 bytes, trying slicing your buffer to suit the max payload size");
+                Debug.LogError("Max UDP payload size is " + MAXPAYLOADSIZE + " bytes, try slicing your buffer to suit the max payload size");
                 return;
             }
             var sendBuf = new ArraySegment<byte>(buffer);

--- a/Runtime/Scripts/MobiledgeXUDPClient.cs.meta
+++ b/Runtime/Scripts/MobiledgeXUDPClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 080a2cf5b6a4a469b929dde25608a8a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Usage example 
``` c-sharp
MobiledgeXUDPClient udpClient =   new MobiledgeXUDPClient(integration.GetHost(),
 integration.GetAppPort(LProto.L_PROTO_UDP).public_port,
 udpReceivePort);

udpClient.Send("msg") or send a byte array

void Update(){
    if (udpClient == null)
            {
                return;
            }
            //udp receive queue
            byte[] udpMsg;
            var udp_queue = udpClient.receiveQueue;
            while (udp_queue.TryPeek(out udpMsg))
            {
                udp_queue.TryDequeue(out udpMsg);
                HandleUDPMessage(udpMsg);
            }
        }

```
According to [RFC 1122](https://tools.ietf.org/html/rfc1122) Max deliverable packet size is 576 

(MAX PAYLOAD = 508 = 576 - 60 IP Header - 8 UDP Header)
<img width="589" alt="Screen Shot 2020-10-05 at 2 50 52 PM" src="https://user-images.githubusercontent.com/24863504/95135990-2e2a4b80-071a-11eb-81b0-b6096047e964.png">

