### PR TITLE
Regions In Editor & useSelectedRegionInProduction EDGECLOUD-3760

### DIFF
--- a/Editor/MobiledgeXEditorWindow.cs
+++ b/Editor/MobiledgeXEditorWindow.cs
@@ -70,33 +70,6 @@ namespace MobiledgeX
         private string sdkVersion;
         private int selectedRegionIndex = 0;
         private string[] regionOptions = new string[5] { "Nearest", "EU", "JP", "KR", "US" };
-        private string region;
-        public string Region
-        {
-            set { region = value; }
-            get
-            {
-                switch (region)
-                {
-                    case "EU":
-                        return EU_DME;
-                    case "KR":
-                        return KR_DME;
-                    case "JP":
-                        return JP_DME;
-                    case "US":
-                        return US_DME;
-                    case "Nearest":
-                    default:
-                        return WIFI_DME;
-                }
-            }
-        }
-        const string WIFI_DME = "wifi.dme.mobiledgex.net";
-        const string EU_DME = "eu-mexdemo.dme.mobiledgex.net";
-        const string KR_DME = "kr-mexdemo.dme.mobiledgex.net";
-        const string US_DME = "us-mexdemo.dme.mobiledgex.net";
-        const string JP_DME = "jp-mexdemo.dme.mobiledgex.net";
 
         #endregion
 
@@ -267,7 +240,7 @@ namespace MobiledgeX
 
             if (EditorGUI.EndChangeCheck())
             {
-                Region = regionOptions[selectedRegionIndex];
+                settings.region = regionOptions[selectedRegionIndex];
             }
             EditorGUILayout.BeginVertical(headerStyle);
             scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Width(300), GUILayout.Height(100));
@@ -381,8 +354,8 @@ namespace MobiledgeX
             {
                 // Register and find cloudlet:
                 clog("Registering to DME ...", "");
-                checkResult = await integration.Register(Region, MatchingEngine.defaultDmeRestPort);
-                bool foundCloudlet = await integration.FindCloudlet(Region, MatchingEngine.defaultDmeRestPort);
+                checkResult = await integration.Register();
+                bool foundCloudlet = await integration.FindCloudlet();
 
                 if (!foundCloudlet)
                 {

--- a/Editor/MobiledgeXEditorWindow.cs
+++ b/Editor/MobiledgeXEditorWindow.cs
@@ -19,6 +19,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using DistributedMatchEngine;
@@ -69,7 +70,7 @@ namespace MobiledgeX
 
         private string sdkVersion;
         private int selectedRegionIndex = 0;
-        private string[] regionOptions = new string[5] { "Nearest", "EU", "JP", "KR", "US" };
+        private List<string> regionOptions = new List<string>(5) { "Nearest", "EU", "JP", "KR", "US" };
 
         #endregion
 
@@ -235,13 +236,29 @@ namespace MobiledgeX
             settings.orgName = EditorGUILayout.TextField("Organization Name", settings.orgName);
             settings.appName = EditorGUILayout.TextField("App Name", settings.appName);
             settings.appVers = EditorGUILayout.TextField("App Version", settings.appVers);
-            EditorGUI.BeginChangeCheck();
-            selectedRegionIndex = EditorGUILayout.Popup("Region (Editor Only)", selectedRegionIndex, regionOptions);
-
-            if (EditorGUI.EndChangeCheck())
+            if (settings.region.Length > 0)
             {
-                settings.region = regionOptions[selectedRegionIndex];
+                try
+                {
+                    selectedRegionIndex = regionOptions.FindIndex(region => region == settings.region);
+                    if (selectedRegionIndex == -1)
+                    {
+                        selectedRegionIndex = 0;
+                    }
+                }
+                catch (ArgumentNullException)
+                {
+                    selectedRegionIndex = 0;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    selectedRegionIndex = 0;
+                }
             }
+            EditorGUI.BeginChangeCheck();
+            selectedRegionIndex = EditorGUILayout.Popup("Region (Editor Only)", selectedRegionIndex, regionOptions.ToArray());
+            EditorGUI.EndChangeCheck();
+            settings.region = regionOptions[selectedRegionIndex];
             EditorGUILayout.BeginVertical(headerStyle);
             scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Width(300), GUILayout.Height(100));
             GUILayout.Label(progressText, labelStyle);

--- a/Resources/MobiledgeXSettings.asset
+++ b/Resources/MobiledgeXSettings.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   appName: 
   appVers:
   authPublicKey: 
+  region:

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -134,16 +134,16 @@ namespace MobiledgeX
         /// RegisterClientException and FindCloudletException will give more details on reason for failure
         /// </summary>
         /// <returns>bool Task</returns>
-        public async Task<bool> RegisterAndFindCloudlet()
+        public async Task<bool> RegisterAndFindCloudlet(string dmeHost = "", uint dmePort = 0)
         {
-            bool registered = await Register();
+            bool registered = await Register(dmeHost, dmePort);
             if (!registered)
             {
                 Debug.LogError("Register Failed!");
                 return false;
             }
             Debug.Log("Register OK!");
-            bool found = await FindCloudlet();
+            bool found = await FindCloudlet(dmeHost, dmePort);
             if (!found)
             {
               Debug.LogError("FindCloudlet Failed!");

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -83,6 +83,33 @@ namespace MobiledgeX
         CarrierInfoClass carrierInfoClass = new CarrierInfoClass(); // used for IsRoaming check
         MelMessaging melMessaging;
 
+        string region
+        {
+            get
+            {
+                switch (settings.region)
+                {
+                    case "EU":
+                        return EU_DME;
+                    case "KR":
+                        return KR_DME;
+                    case "JP":
+                        return JP_DME;
+                    case "US":
+                        return US_DME;
+                    case "Nearest":
+                    default:
+                        return WIFI_DME;
+                }
+            }
+        }
+
+        const string WIFI_DME = "wifi.dme.mobiledgex.net";
+        const string EU_DME = "eu-mexdemo.dme.mobiledgex.net";
+        const string KR_DME = "kr-mexdemo.dme.mobiledgex.net";
+        const string US_DME = "us-mexdemo.dme.mobiledgex.net";
+        const string JP_DME = "jp-mexdemo.dme.mobiledgex.net";
+
         /// <summary>
         /// Constructor for MobiledgeXIntegration. This class has functions that wrap DistributedMatchEngine functions for ease of use
         /// </summary>
@@ -107,16 +134,16 @@ namespace MobiledgeX
         /// RegisterClientException and FindCloudletException will give more details on reason for failure
         /// </summary>
         /// <returns>bool Task</returns>
-        public async Task<bool> RegisterAndFindCloudlet(string dmeHost = null, uint dmePort = 0)
+        public async Task<bool> RegisterAndFindCloudlet()
         {
-            bool registered = await Register(dmeHost, dmePort);
+            bool registered = await Register();
             if (!registered)
             {
                 Debug.LogError("Register Failed!");
                 return false;
             }
             Debug.Log("Register OK!");
-            bool found = await FindCloudlet(dmeHost, dmePort);
+            bool found = await FindCloudlet();
             if (!found)
             {
               Debug.LogError("FindCloudlet Failed!");

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -134,7 +134,7 @@ namespace MobiledgeX
         /// RegisterClientException and FindCloudletException will give more details on reason for failure
         /// </summary>
         /// <returns>bool Task</returns>
-        public async Task<bool> RegisterAndFindCloudlet(string dmeHost = "", uint dmePort = 0)
+        public async Task<bool> RegisterAndFindCloudlet(string dmeHost = null, uint dmePort = 0)
         {
             bool registered = await Register(dmeHost, dmePort);
             if (!registered)

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -64,8 +64,8 @@ namespace MobiledgeX
         /// <summary>
         /// You don't need this option in UnityEditor by default the region used will be the region selected in MobiledgeX Editor Window
         /// Set to true to use the Region selected in MobiledgeX Editor Window in production
-        /// its not recommended to use this option in production since the SDK will automatically select the best region
-        /// you can use this option for non-sim card devices such as Oculus or MagicLeap
+        /// It's not recommended to use this option in production since the SDK will automatically select the best region.
+        /// You can use this option for non-sim card devices such as Oculus or MagicLeap
         /// </summary>
         public bool useSelectedRegionInProduction = false;
 

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -111,8 +111,8 @@ namespace MobiledgeX
                         Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
                         reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
 #else
-                    Debug.Log("MobiledgeX: Doing Register Client, with req: " + req);
-                    reply = await matchingEngine.RegisterClient(req);
+                        Debug.Log("MobiledgeX: Doing Register Client, with req: " + req);
+                        reply = await matchingEngine.RegisterClient(req);
 #endif
                     }
                     else

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -74,7 +74,7 @@ namespace MobiledgeX
         /// Wrapper for Register Client. First call to establish the connection with your backend(server) deployed on MobiledgeX
         /// </summary>
         /// <returns>bool Task</returns>
-        public async Task<bool> Register()
+        public async Task<bool> Register(string dmeHost = "", uint dmePort = 0)
         {
             latestRegisterStatus = false;
 
@@ -97,21 +97,29 @@ namespace MobiledgeX
             RegisterClientReply reply = null;
             try
             {
-                if (!useSelectedRegionInProduction)
+                if (dmeHost != "" && dmePort != 0)
                 {
+                    Debug.Log("MobiledgeX: Doing Register Client with DME: " + dmeHost + ", p: " + dmePort + " with req: " + req);
+                    reply = await matchingEngine.RegisterClient(dmeHost, dmePort, req);
+                }
+                else
+                { 
+                    if (!useSelectedRegionInProduction)
+                    {
 #if UNITY_EDITOR
-                    Debug.Log("MobiledgeX: Doing Register Client with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
-                    Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
-                    reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
+                        Debug.Log("MobiledgeX: Doing Register Client with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                        Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
+                        reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
 #else
                     Debug.Log("MobiledgeX: Doing Register Client, with req: " + req);
                     reply = await matchingEngine.RegisterClient(req);
 #endif
-                }
-                else
-                {
+                    }
+                    else
+                    {
                     Debug.Log("MobiledgeX: Doing Register Client with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
                     reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
+                    }
                 }
             }
             catch (HttpException httpe)
@@ -147,7 +155,7 @@ namespace MobiledgeX
         /// To use Performance mode. Call UseFindCloudletPerformanceMode(true)
         /// </summary>
         /// <returns>FindCloudletReply Task</returns>
-        public async Task<bool> FindCloudlet()
+        public async Task<bool> FindCloudlet(string dmeHost = "", uint dmePort = 0)
         {
             latestFindCloudletReply = null;
             if (!latestRegisterStatus)
@@ -174,21 +182,29 @@ namespace MobiledgeX
                 }
                 Debug.Log("FindCloudlet Location: " + location.longitude + ", lat: " + location.latitude);
                 FindCloudletRequest req = matchingEngine.CreateFindCloudletRequest(location, "");
-                if (!useSelectedRegionInProduction)
+                if (dmeHost != "" && dmePort != 0)
                 {
-#if UNITY_EDITOR
-                    Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
-                    Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
-                    reply = await matchingEngine.FindCloudlet(region, MatchingEngine.defaultDmeRestPort, req);
-#else
-                    Debug.Log("MobiledgeX: Doing FindCloudlet, with req: " + req);
-                    reply = await matchingEngine.FindCloudlet(req, mode);
-#endif
+                    Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + dmeHost + ", p: " + dmePort + " with req: " + req);
+                    reply = await matchingEngine.FindCloudlet(dmeHost, dmePort, req, mode);
                 }
                 else
-                {
-                    Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
-                    reply = await matchingEngine.FindCloudlet(region, MatchingEngine.defaultDmeRestPort, req, mode);
+                { 
+                    if (!useSelectedRegionInProduction)
+                    {
+#if UNITY_EDITOR
+                        Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                        Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
+                        reply = await matchingEngine.FindCloudlet(region, MatchingEngine.defaultDmeRestPort, req);
+#else
+                        Debug.Log("MobiledgeX: Doing FindCloudlet, with req: " + req);
+                        reply = await matchingEngine.FindCloudlet(req, mode);
+#endif
+                    }
+                    else
+                    {
+                        Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                        reply = await matchingEngine.FindCloudlet(region, MatchingEngine.defaultDmeRestPort, req, mode);
+                    }
                 }
             }
             catch (HttpException httpe)

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -61,12 +61,20 @@ namespace MobiledgeX
         /// </summary>
         public bool useFallbackLocation = false;
 
+        /// <summary>
+        /// You don't need this option in UnityEditor by default the region used will be the region selected in MobiledgeX Editor Window
+        /// Set to true to use the Region selected in MobiledgeX Editor Window in production
+        /// its not recommended to use this option in production since the SDK will automatically select the best region
+        /// you can use this option for non-sim card devices such as Oculus or MagicLeap
+        /// </summary>
+        public bool useSelectedRegionInProduction = false;
+
         /// Call once, or when the carrier changes. May throw DistributedMatchEngine.HttpException.
         /// <summary>
         /// Wrapper for Register Client. First call to establish the connection with your backend(server) deployed on MobiledgeX
         /// </summary>
         /// <returns>bool Task</returns>
-        public async Task<bool> Register(string dmeHost = null, uint dmePort = 0)
+        public async Task<bool> Register()
         {
             latestRegisterStatus = false;
 
@@ -82,44 +90,50 @@ namespace MobiledgeX
             }
             catch (CarrierInfoException cie)
             {
-                Debug.LogError("Register Exception: " + cie.Message);
+                Debug.LogError("MobiledgeX: Register Exception: " + cie.Message);
                 throw new RegisterClientException(cie.Message);
             }
 
             RegisterClientReply reply = null;
             try
             {
-                if (dmeHost == null || dmePort == 0)
+                if (!useSelectedRegionInProduction)
                 {
-                    Debug.Log("Doing Register Client, with req: " + req);
+#if UNITY_EDITOR
+                        Debug.Log("MobiledgeX: Doing Register Client with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                        Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
+                        reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
+#else
+                    Debug.Log("MobiledgeX: Doing Register Client, with req: " + req);
                     reply = await matchingEngine.RegisterClient(req);
+#endif
                 }
                 else
                 {
-                    Debug.Log("Doing Register Client with DME: " + dmeHost + ", p: " + dmePort + " with req: " + req);
-                    reply = await matchingEngine.RegisterClient(dmeHost, dmePort, req);
+                    Debug.Log("MobiledgeX: Doing Register Client with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                    reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
                 }
             }
             catch (HttpException httpe)
             {
-                Debug.LogError("RegisterClient HttpException: " + httpe.Message);
+                Debug.LogError("MobiledgeX: RegisterClient HttpException: " + httpe.Message);
                 throw new RegisterClientException("RegisterClient Exception: " + httpe.Message + ", HTTP StatusCode: " + httpe.HttpStatusCode + ", API ErrorCode: " + httpe.ErrorCode + "\nStack: " + httpe.StackTrace);
             }
             catch (Exception e)
             {
-                Debug.LogError("RegisterClient Exception: " + e.Message);
+                Debug.LogError("MobiledgeX: RegisterClient Exception: " + e.Message);
                 throw e;
             }
             finally
             {
                 if (reply == null)
                 {
-                    Debug.LogError("Register reply NULL!");
+                    Debug.LogError("MobiledgeX: Register reply NULL!");
                     throw new RegisterClientException("RegisterClient returned null.");
                 }
                 if (reply.status != ReplyStatus.RS_SUCCESS)
                 {
-                    Debug.LogError("Register Failed: " + reply.status);
+                    Debug.LogError("MobiledgeX: Register Failed: " + reply.status);
                     throw new RegisterClientException("Bad RegisterClient. RegisterClient status is " + reply.status);
                 }
             }
@@ -133,7 +147,7 @@ namespace MobiledgeX
         /// To use Performance mode. Call UseFindCloudletPerformanceMode(true)
         /// </summary>
         /// <returns>FindCloudletReply Task</returns>
-        public async Task<bool> FindCloudlet(string dmeHost = null, uint dmePort = 0)
+        public async Task<bool> FindCloudlet()
         {
             latestFindCloudletReply = null;
             if (!latestRegisterStatus)
@@ -160,16 +174,21 @@ namespace MobiledgeX
                 }
                 Debug.Log("FindCloudlet Location: " + location.longitude + ", lat: " + location.latitude);
                 FindCloudletRequest req = matchingEngine.CreateFindCloudletRequest(location, "");
-
-                if (dmeHost == null || dmePort == 0)
+                if (!useSelectedRegionInProduction)
                 {
-                    Debug.Log("Doing FindCloudlet, with req: " + req);
+#if UNITY_EDITOR
+                    Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                    Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
+                    reply = await matchingEngine.FindCloudlet(region, MatchingEngine.defaultDmeRestPort, req);
+#else
+                    Debug.Log("MobiledgeX: Doing FindCloudlet, with req: " + req);
                     reply = await matchingEngine.FindCloudlet(req, mode);
+#endif
                 }
                 else
                 {
-                    Debug.Log("Doing FindCloudlet with DME: " + dmeHost + ", p: " + dmePort + " with req: " + req);
-                    reply = await matchingEngine.FindCloudlet(dmeHost, dmePort, req, mode);
+                    Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                    reply = await matchingEngine.FindCloudlet(region, MatchingEngine.defaultDmeRestPort, req, mode);
                 }
             }
             catch (HttpException httpe)

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -100,9 +100,9 @@ namespace MobiledgeX
                 if (!useSelectedRegionInProduction)
                 {
 #if UNITY_EDITOR
-                        Debug.Log("MobiledgeX: Doing Register Client with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
-                        Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
-                        reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
+                    Debug.Log("MobiledgeX: Doing Register Client with DME: " + region + ", p: " + MatchingEngine.defaultDmeRestPort + " with req: " + req);
+                    Debug.LogWarning("MobiledgeX: Region Selection will work only in UnityEditor not on Mobile Devices");
+                    reply = await matchingEngine.RegisterClient(region, MatchingEngine.defaultDmeRestPort, req);
 #else
                     Debug.Log("MobiledgeX: Doing Register Client, with req: " + req);
                     reply = await matchingEngine.RegisterClient(req);

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -74,7 +74,7 @@ namespace MobiledgeX
         /// Wrapper for Register Client. First call to establish the connection with your backend(server) deployed on MobiledgeX
         /// </summary>
         /// <returns>bool Task</returns>
-        public async Task<bool> Register(string dmeHost = "", uint dmePort = 0)
+        public async Task<bool> Register(string dmeHost = null, uint dmePort = 0)
         {
             latestRegisterStatus = false;
 
@@ -97,7 +97,7 @@ namespace MobiledgeX
             RegisterClientReply reply = null;
             try
             {
-                if (dmeHost != "" && dmePort != 0)
+                if (dmeHost != null && dmePort != 0)
                 {
                     Debug.Log("MobiledgeX: Doing Register Client with DME: " + dmeHost + ", p: " + dmePort + " with req: " + req);
                     reply = await matchingEngine.RegisterClient(dmeHost, dmePort, req);
@@ -155,7 +155,7 @@ namespace MobiledgeX
         /// To use Performance mode. Call UseFindCloudletPerformanceMode(true)
         /// </summary>
         /// <returns>FindCloudletReply Task</returns>
-        public async Task<bool> FindCloudlet(string dmeHost = "", uint dmePort = 0)
+        public async Task<bool> FindCloudlet(string dmeHost = null, uint dmePort = 0)
         {
             latestFindCloudletReply = null;
             if (!latestRegisterStatus)
@@ -182,7 +182,7 @@ namespace MobiledgeX
                 }
                 Debug.Log("FindCloudlet Location: " + location.longitude + ", lat: " + location.latitude);
                 FindCloudletRequest req = matchingEngine.CreateFindCloudletRequest(location, "");
-                if (dmeHost != "" && dmePort != 0)
+                if (dmeHost != null && dmePort != 0)
                 {
                     Debug.Log("MobiledgeX: Doing FindCloudlet with DME: " + dmeHost + ", p: " + dmePort + " with req: " + req);
                     reply = await matchingEngine.FindCloudlet(dmeHost, dmePort, req, mode);

--- a/Runtime/Scripts/MobiledgeXSettings.cs
+++ b/Runtime/Scripts/MobiledgeXSettings.cs
@@ -27,5 +27,6 @@ namespace MobiledgeX
         public string appName;
         public string appVers;
         public string authPublicKey;
+        public string region;
     }
 }


### PR DESCRIPTION
(Regions in Editor)
The changes discussed on Slack:
In MobiledgeX Editor Window a developer can select a region , Register() , FindCloudlet() will be executed using the selected region DME **only in the UnityEditor**.
If a developer wants to override the DME HOST for production for non sim card device (ex. Magic Leap)
```c-sharp
integration.useSelectedRegionInProduction = true;
integration.RegisterAndFindCloudlet();
```
@lgarner  this will affect the MagicLeap Demo so you will need something like this  https://github.com/mobiledgex/unity-samples/pull/5

Added check to prevent region corruption in the inspector
