### PR TITLE
Fallback Location from IP Address EDGECLOUD-3750

### DIFF
--- a/Resources/Examples/EdgeMultiplay.unitypackage.meta
+++ b/Resources/Examples/EdgeMultiplay.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eee78bffe6b7c4248a3bb2d83c7588c1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -134,12 +134,14 @@ namespace MobiledgeX
 #elif UNITY_IOS
   public Dictionary<string, string> GetDeviceInfo()
   {
-    Debug.LogFormat("[{0}] DeviceInfo not implemented!", TAG);
+    Debug.Log("DeviceInfo not implemented!");
+     return null;
   }
 #else // Unsupported platform.
   public Dictionary<string, string> GetDeviceInfo()
   {
-    Debug.LogFormat("[{0}] DeviceInfo not implemented!", TAG);
+    Debug.Log("DeviceInfo not implemented!");
+     return null;
   }
 #endif
   }

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -78,7 +78,7 @@ namespace MobiledgeX
         FindCloudletMode mode = FindCloudletMode.PROXIMITY; // FindCloudlet mode
         AppPort latestAppPort = null;
         AppPort[] latestAppPortList = null;
-        Location fallbackLocation = new Location(-121.8863286, 37.3382082);
+        Location fallbackLocation = new Location(0,0);
         CarrierInfoClass carrierInfoClass = new CarrierInfoClass(); // used for IsRoaming check
         MelMessaging melMessaging;
 

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -165,6 +165,11 @@ namespace MobiledgeX
 
             try
             {
+                if(fallbackLocation.Longitude == 0 && fallbackLocation.Latitude == 0)
+                {
+                    LocationFromIPAddress locationFromIP = await GetLocationFromIP();
+                    fallbackLocation = new Location(locationFromIP.longitude, locationFromIP.latitude);
+                }
                 await UpdateLocationAndCarrierInfo();
             }
             catch (CarrierInfoException cie)


### PR DESCRIPTION
**Currently**, We use a hard coded location as the default for the Fallback location (SanJose)
**New approach** is
 Check if Fallback Location is empty ,if so get location from the IP Address using this [api](https://freegeoip.app/) , In case of failure or any exception thrown use SanJose as the default  fallback location.
 >If the developer already used SetFallbackLocation() this request won't be used

See full description of the feature [here](https://mobiledgex.atlassian.net/browse/EDGECLOUD-3750) 