### PR TITLE
EDGECLOUD-3907: Objective C Unity Extra Device Info

### DIFF
--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -153,7 +153,7 @@ char* _getIPAddress(char* netInterfaceType)
     
     if (getifaddrs(&interfaces) == -1)
     {
-        return "";
+        return convertToCStr(@"" UTF8String);
     }
     struct ifaddrs* runner = interfaces;
     while (runner != NULL)
@@ -292,24 +292,20 @@ char* _getISOCountryCodeFromCarrier()
 }
 
 char* _getManufacturerCode() {
-    NSLog(@"in get manu code");
-    return "Apple";
+    return convertToCStr([@"Apple" UTF8String]);
 }
 
 char* _getDeviceSoftwareVersion() {
-    NSLog(@"in get software vers");
     UIDevice* device = UIDevice.currentDevice;
     return convertToCStr([device.systemVersion UTF8String]);
 }
 
 char* _getDeviceModel() {
-    NSLog(@"in get model");
     UIDevice* device = UIDevice.currentDevice;
     return convertToCStr([device.model UTF8String]);
 }
 
 char* _getOperatingSystem() {
-    NSLog(@"in get os");
     UIDevice* device = UIDevice.currentDevice;
     return convertToCStr([device.systemName UTF8String]);
 }

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -292,20 +292,24 @@ char* _getISOCountryCodeFromCarrier()
 }
 
 char* _getManufacturerCode() {
+    NSLog(@"in get manu code");
     return "Apple";
 }
 
 char* _getDeviceSoftwareVersion() {
+    NSLog(@"in get software vers");
     UIDevice* device = UIDevice.currentDevice;
     return convertToCStr([device.systemVersion UTF8String]);
 }
 
 char* _getDeviceModel() {
+    NSLog(@"in get model");
     UIDevice* device = UIDevice.currentDevice;
     return convertToCStr([device.model UTF8String]);
 }
 
 char* _getOperatingSystem() {
+    NSLog(@"in get os");
     UIDevice* device = UIDevice.currentDevice;
     return convertToCStr([device.systemName UTF8String]);
 }

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -153,7 +153,7 @@ char* _getIPAddress(char* netInterfaceType)
     
     if (getifaddrs(&interfaces) == -1)
     {
-        return convertToCStr(@"" UTF8String);
+        return convertToCStr([@"" UTF8String]);
     }
     struct ifaddrs* runner = interfaces;
     while (runner != NULL)

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -36,7 +36,6 @@
 @property CTTelephonyNetworkInfo *networkInfo;
 @property NSDictionary<NSString *,CTCarrier *>* ctCarriers;
 @property CTCarrier* lastCarrier;
-@property UIDevice* device;
 @end
 @implementation NetworkState
 @end
@@ -49,7 +48,6 @@ void _ensureMatchingEnginePlatformIntegration() {
     {
         networkState = [[NetworkState alloc] init];
         networkState.networkInfo = [[CTTelephonyNetworkInfo alloc] init];
-        networkState.device = UIDevice.currentDevice;
         // Give it an initial value, if any.
         if (@available(iOS 12.1, *))
         {
@@ -240,15 +238,15 @@ unsigned int _getCellID()
 
 char* _getUniqueID()
 {
-    _ensureMatchingEnginePlatformIntegration();
-    NSUUID *uuid = networkState.device.identifierForVendor;
+    UIDevice* device = UIDevice.currentDevice;
+    NSUUID *uuid = device.identifierForVendor;
     return convertToCStr([uuid.UUIDString UTF8String]);
 }
 
 char* _getUniqueIDType()
 {
-    _ensureMatchingEnginePlatformIntegration();
-    NSString *aid = networkState.device.model;
+    UIDevice* device = UIDevice.currentDevice;
+    NSString *aid = device.model;
     return convertToCStr([aid UTF8String]);
 }
 
@@ -294,20 +292,20 @@ char* _getISOCountryCodeFromCarrier()
 }
 
 char* _getManufacturerCode() {
-    return "Apple"
+    return "Apple";
 }
 
-char * _getDeviceSoftwareVersion() {
-    _ensureMatchingEnginePlatformIntegration();
-    return convertToCStr([networkState.device.systemVersion UTF8String]);
+char* _getDeviceSoftwareVersion() {
+    UIDevice* device = UIDevice.currentDevice;
+    return convertToCStr([device.systemVersion UTF8String]);
 }
 
 char* _getDeviceModel() {
-    _ensureMatchingEnginePlatformIntegration();
-    return convertToCStr([networkState.device.model UTF8String]);
+    UIDevice* device = UIDevice.currentDevice;
+    return convertToCStr([device.model UTF8String]);
 }
 
 char* _getOperatingSystem() {
-    _ensureMatchingEnginePlatformIntegration();
-    return convertToCStr([networkState.device.systemName UTF8String]);
+    UIDevice* device = UIDevice.currentDevice;
+    return convertToCStr([device.systemName UTF8String]);
 }

--- a/Runtime/Plugins/iOS/PlatformIntegration.m
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m
@@ -293,18 +293,21 @@ char* _getISOCountryCodeFromCarrier()
     return convertToCStr([capitalizedISOCC UTF8String]);
 }
 
-NSDictionary<char*, char*> _getDeviceInfo()
-{
+char* _getManufacturerCode() {
+    return "Apple"
+}
+
+char * _getDeviceSoftwareVersion() {
     _ensureMatchingEnginePlatformIntegration();
-    NSDictionary *deviceInfo = [NSDictionary dictionary];
-    
-    deviceInfo["ManufacturereCode"] = "Apple";
-    // Get device system information
-    deviceInfo["DeviceSoftwareVersion"] = convertToCStr([networkState.device.systemVersion UTF8String]);
-    deviceInfo["DeviceModel"] = convertToCStr([networkState.device.model UTF8String]);
-    deviceInfo["OperatingSystem"] = convertToCStr([networkState.device.systemName UTF8String]);
-    // Get Carrier/ISO information
-    deviceInfo["SimOperatorName"] = _getCurrentCarrierName();
-    deviceInfo["NetworkCountryIso"] = _getISOCountryCodeFromGPS();
-    deviceInfo["SimCountryCodeIso"] = _getISOCountryCodeFromCarrier();
+    return convertToCStr([networkState.device.systemVersion UTF8String]);
+}
+
+char* _getDeviceModel() {
+    _ensureMatchingEnginePlatformIntegration();
+    return convertToCStr([networkState.device.model UTF8String]);
+}
+
+char* _getOperatingSystem() {
+    _ensureMatchingEnginePlatformIntegration();
+    return convertToCStr([networkState.device.systemName UTF8String]);
 }

--- a/Runtime/Plugins/iOS/PlatformIntegration.m.meta
+++ b/Runtime/Plugins/iOS/PlatformIntegration.m.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:
@@ -68,7 +68,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:

--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -470,7 +470,7 @@ namespace MobiledgeX
       return false;
     }
 
-    private async Task<string> ConvertGPSToISOCountryCode(double longitude, double latitude)
+    public async Task<string> ConvertGPSToISOCountryCode(double longitude, double latitude)
     {
       if (Application.platform == RuntimePlatform.IPhonePlayer)
       {
@@ -488,7 +488,7 @@ namespace MobiledgeX
       return null;
     }  
 
-    private string GetISOCountryCodeFromGPS()
+    public string GetISOCountryCodeFromGPS()
     {
       string isoCC = null;
       if (Application.platform == RuntimePlatform.IPhonePlayer)
@@ -498,7 +498,7 @@ namespace MobiledgeX
       return isoCC;
     }
 
-    private string GetISOCountryCodeFromCarrier()
+    public string GetISOCountryCodeFromCarrier()
     {
       string isoCC = null;
       if (Application.platform == RuntimePlatform.IPhonePlayer)

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -150,15 +150,23 @@ namespace MobiledgeX
     Dictionary<string, string> deviceInfo = new Dictionary<string, string>();
     if (Application.platform == RuntimePlatform.IPhonePlayer)
     {
+        Debug.Log("is iphone player");
       // Fill in device system info
       deviceInfo["ManufacturerCode"] = _getManufacturerCode();
+        Debug.Log("1");
       deviceInfo["DeviceSoftwareVersion"] = _getDeviceSoftwareVersion();
+        Debug.Log("2");
       deviceInfo["DeviceModel"] = _getDeviceModel();
+        Debug.Log("3");
       deviceInfo["OperatingSystem"] = _getOperatingSystem();
+        Debug.Log("4");
       // Fill in carrier/ISO info
       CarrierInfoClass carrierInfo = new CarrierInfoClass();
+        Debug.Log("5");
       deviceInfo["SimOperatorName"] = carrierInfo.GetCurrentCarrierName();
+        Debug.Log("6");
       deviceInfo["SimCountryCodeIso"] = carrierInfo.GetISOCountryCodeFromCarrier();
+        Debug.Log("7");
     }
     return deviceInfo;
   }

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -150,23 +150,15 @@ namespace MobiledgeX
     Dictionary<string, string> deviceInfo = new Dictionary<string, string>();
     if (Application.platform == RuntimePlatform.IPhonePlayer)
     {
-        Debug.Log("is iphone player");
       // Fill in device system info
       deviceInfo["ManufacturerCode"] = _getManufacturerCode();
-        Debug.Log("1");
       deviceInfo["DeviceSoftwareVersion"] = _getDeviceSoftwareVersion();
-        Debug.Log("2");
       deviceInfo["DeviceModel"] = _getDeviceModel();
-        Debug.Log("3");
       deviceInfo["OperatingSystem"] = _getOperatingSystem();
-        Debug.Log("4");
       // Fill in carrier/ISO info
       CarrierInfoClass carrierInfo = new CarrierInfoClass();
-        Debug.Log("5");
       deviceInfo["SimOperatorName"] = carrierInfo.GetCurrentCarrierName();
-        Debug.Log("6");
       deviceInfo["SimCountryCodeIso"] = carrierInfo.GetISOCountryCodeFromCarrier();
-        Debug.Log("7");
     }
     return deviceInfo;
   }

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using DistributedMatchEngine;
 using MobiledgeX;
 using UnityEngine;
@@ -133,14 +134,31 @@ namespace MobiledgeX
     }
 #elif UNITY_IOS
   [DllImport("__Internal")]
-  private static extern Dictionary<string, string> _getDeviceInfo();
+  private static extern string _getManufacturerCode();
+
+  [DllImport("__Internal")]
+  private static extern string _getDeviceSoftwareVersion();
+
+  [DllImport("__Internal")]
+  private static extern string _getDeviceModel();
+
+  [DllImport("__Internal")]
+  private static extern string _getOperatingSystem();
 
   public Dictionary<string, string> GetDeviceInfo()
   {
     Dictionary<string, string> deviceInfo = new Dictionary<string, string>();
     if (Application.platform == RuntimePlatform.IPhonePlayer)
     {
-      deviceInfo = _getDeviceInfo());
+      // Fill in device system info
+      deviceInfo["ManufacturerCode"] = _getManufacturerCode();
+      deviceInfo["DeviceSoftwareVersion"] = _getDeviceSoftwareVersion();
+      deviceInfo["DeviceModel"] = _getDeviceModel();
+      deviceInfo["OperatingSystem"] = _getOperatingSystem();
+      // Fill in carrier/ISO info
+      CarrierInfoClass carrierInfo = new CarrierInfoClass();
+      deviceInfo["SimOperatorName"] = carrierInfo.GetCurrentCarrierName();
+      deviceInfo["SimCountryCodeIso"] = carrierInfo.GetISOCountryCodeFromCarrier();
     }
     return deviceInfo;
   }

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -132,16 +132,23 @@ namespace MobiledgeX
       return map;
     }
 #elif UNITY_IOS
+  [DllImport("__Internal")]
+  private static extern Dictionary<string, string> _getDeviceInfo();
+
   public Dictionary<string, string> GetDeviceInfo()
   {
-    Debug.Log("DeviceInfo not implemented!");
-     return null;
+    Dictionary<string, string> deviceInfo = new Dictionary<string, string>();
+    if (Application.platform == RuntimePlatform.IPhonePlayer)
+    {
+      deviceInfo = _getDeviceInfo());
+    }
+    return deviceInfo;
   }
 #else // Unsupported platform.
   public Dictionary<string, string> GetDeviceInfo()
   {
-    Debug.Log("DeviceInfo not implemented!");
-     return null;
+    Debug.LogFormat("DeviceInfo not implemented!");
+    return null;
   }
 #endif
   }

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -7,8 +7,9 @@ using DistributedMatchEngine;
 using System.Threading.Tasks;
 using System.Net.Http;
 using System;
+using System.Collections.Generic;
 
-    [RequireComponent(typeof(MobiledgeX.LocationService))]
+[RequireComponent(typeof(MobiledgeX.LocationService))]
     public class ExampleRest : MonoBehaviour
     {
         MobiledgeXIntegration mxi;
@@ -22,6 +23,11 @@ using System;
         async void GetEdgeConnection()
         {
             mxi = new MobiledgeXIntegration();
+            var deviceInfo = await mxi.GetDeviceInfo();
+            foreach (KeyValuePair<string, string> pair in deviceInfo)
+            {
+                Debug.Log("Key is " + pair.Key + ", and Value is " + pair.Value);
+            }
             try
             {
                 await mxi.RegisterAndFindCloudlet();

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -23,11 +23,6 @@ using System.Collections.Generic;
         async void GetEdgeConnection()
         {
             mxi = new MobiledgeXIntegration();
-            var deviceInfo = await mxi.GetDeviceInfo();
-            foreach (KeyValuePair<string, string> pair in deviceInfo)
-            {
-                Debug.Log("DeviceInfo: Key is " + pair.Key + ", and Value is " + pair.Value);
-            }
             try
             {
                 await mxi.RegisterAndFindCloudlet();

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -24,11 +24,9 @@ using System.Collections.Generic;
         {
             mxi = new MobiledgeXIntegration();
             var deviceInfo = await mxi.GetDeviceInfo();
-            Debug.Log("got device info");
-
             foreach (KeyValuePair<string, string> pair in deviceInfo)
             {
-                Debug.Log("Key is " + pair.Key + ", and Value is " + pair.Value);
+                Debug.Log("DeviceInfo: Key is " + pair.Key + ", and Value is " + pair.Value);
             }
             try
             {

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -24,6 +24,8 @@ using System.Collections.Generic;
         {
             mxi = new MobiledgeXIntegration();
             var deviceInfo = await mxi.GetDeviceInfo();
+            Debug.Log("got device info");
+
             foreach (KeyValuePair<string, string> pair in deviceInfo)
             {
                 Debug.Log("Key is " + pair.Key + ", and Value is " + pair.Value);

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -327,7 +327,7 @@ namespace MobiledgeX
             var deviceInfo = matchingEngine.deviceInfo.GetDeviceInfo();
 #if UNITY_IOS
             if (deviceInfo == null || deviceInfo.Count == 0) {
-                return null;
+                return new Dictionary<string, string>();
             }
             UpdateLocationFromDevice();
             deviceInfo["NetworkCountryIso"] = await carrierInfoClass.ConvertGPSToISOCountryCode(location.longitude, location.latitude);

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -20,6 +20,7 @@ using UnityEngine;
 using DistributedMatchEngine;
 using System.Threading.Tasks;
 using System.Net.Sockets;
+using System.Collections.Generic;
 
 /*
 * Helper functions, private functions, and exceptions used to implement MobiledgeXIntegration wrapper functions
@@ -320,6 +321,18 @@ namespace MobiledgeX
             }
         }
 #endif
+
+        public async Task<Dictionary<string, string>> GetDeviceInfo()
+        {
+            var deviceInfo = matchingEngine.deviceInfo.GetDeviceInfo();
+#if UNITY_IOS
+            if (deviceInfo == null) {
+                return null;
+            }
+            deviceInfo["NetworkCountryIso"] = await carrierInfoClass.ConvertGPSToISOCountryCode(location.longitude, location.latitude);
+#endif
+            return deviceInfo;
+        }
 
         /// <summary>
         /// Checks whether the default netowrk data path Edge is Enabled on the device or not, Edge requires connections to run over cellular interface.

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -329,6 +329,7 @@ namespace MobiledgeX
             if (deviceInfo == null || deviceInfo.Count == 0) {
                 return null;
             }
+            UpdateLocationFromDevice();
             deviceInfo["NetworkCountryIso"] = await carrierInfoClass.ConvertGPSToISOCountryCode(location.longitude, location.latitude);
 #endif
             return deviceInfo;

--- a/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
+++ b/Runtime/Scripts/MobiledgeXIntegrationHelper.cs
@@ -326,7 +326,7 @@ namespace MobiledgeX
         {
             var deviceInfo = matchingEngine.deviceInfo.GetDeviceInfo();
 #if UNITY_IOS
-            if (deviceInfo == null) {
+            if (deviceInfo == null || deviceInfo.Count == 0) {
                 return null;
             }
             deviceInfo["NetworkCountryIso"] = await carrierInfoClass.ConvertGPSToISOCountryCode(location.longitude, location.latitude);


### PR DESCRIPTION
Update Objective C plugin with functions that grab device info (char* _getManufacturerCode(), char* _getDeviceSoftwareVersion(), char* _getDeviceModel(), char* _getOperatingSystem()). 

I use these functions in the DeviceInfoClass:GetDeviceInfo function to populate the device info dictionary.

(Note: ISO code from gps location requires async code, so I added an async GetDeviceInfo() function in MobiledgeXIntegration that adds "NetworkCountryIso" to the device info dictionary after grabbing it from DeviceInfoClass)