### PR TITLE
Capture SDK Version only on DeviceInfo if the device  have Oculus in XR Settings EDGECLOUD-4335

### DIFF
--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -64,11 +64,10 @@ namespace MobiledgeX
       CarrierInfoClass carrierInfo = new CarrierInfoClass();
       Dictionary<string, string> map;
       int sdk_int = carrierInfo.getAndroidSDKVers();
-      if (UnityEngine.XR.XRSettings.isDeviceActive && UnityEngine.XR.XRSettings.loadedDeviceName.Contains("oculus"))
+      if (UnityEngine.XR.XRSettings.enabled)
       {
-           map = new Dictionary<string, string>();
-           map["Build.VERSION.SDK_INT"] = sdk_int.ToString();
-           return map;
+          map["Build.VERSION.SDK_INT"] = sdk_int.ToString();
+          return map;
       }
       AndroidJavaObject telephonyManager = carrierInfo.GetTelephonyManager();
       if (telephonyManager == null)

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -64,7 +64,7 @@ namespace MobiledgeX
       CarrierInfoClass carrierInfo = new CarrierInfoClass();
       Dictionary<string, string> map;
       int sdk_int = carrierInfo.getAndroidSDKVers();
-      if (UnityEngine.XR.XRSettings.enabled)
+      if (UnityEngine.XR.XRSettings.loadedDeviceName.Contains("oculus"))
       {
           map["Build.VERSION.SDK_INT"] = sdk_int.ToString();
           return map;

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -1,4 +1,21 @@
-﻿using System;
+﻿/**
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
+ * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using DistributedMatchEngine;
@@ -45,20 +62,22 @@ namespace MobiledgeX
     public Dictionary<string, string> GetDeviceInfo()
     {
       CarrierInfoClass carrierInfo = new CarrierInfoClass();
-      AndroidJavaObject telephonyManager = carrierInfo.GetTelephonyManager();
       Dictionary<string, string> map;
-
+      int sdk_int = carrierInfo.getAndroidSDKVers();
+      if (UnityEngine.XR.XRSettings.isDeviceActive && UnityEngine.XR.XRSettings.loadedDeviceName.Contains("oculus"))
+      {
+           map = new Dictionary<string, string>();
+           map["Build.VERSION.SDK_INT"] = sdk_int.ToString();
+           return map;
+      }
+      AndroidJavaObject telephonyManager = carrierInfo.GetTelephonyManager();
       if (telephonyManager == null)
       {
         Debug.Log("No TelephonyManager!");
         return null;
       }
       map = new Dictionary<string, string>();
-
-      AndroidJavaClass versionClass = new AndroidJavaClass("android.os.Build$VERSION");
-      int sdk_int = PlatformIntegrationUtil.GetStatic<int>(versionClass, "SDK_INT");
       map["Build.VERSION.SDK_INT"] = sdk_int.ToString();
-
       const string readPhoneStatePermissionString = "android.permission.READ_PHONE_STATE";
       try
       {
@@ -163,7 +182,7 @@ namespace MobiledgeX
     return deviceInfo;
   }
 #else // Unsupported platform.
-  public Dictionary<string, string> GetDeviceInfo()
+        public Dictionary<string, string> GetDeviceInfo()
   {
     Debug.LogFormat("DeviceInfo not implemented!");
     return null;


### PR DESCRIPTION
Capture SDK Version only on DeviceInfoIntegration if the device is Oculus, GetTelephonyManager() cause multiple exceptions to be thrown on XR Devices that doesn't have Sim Card.
