### PR TITLE
Default Config and Examples

### DIFF
--- a/Resources/MobiledgeXSettings.asset
+++ b/Resources/MobiledgeXSettings.asset
@@ -20,8 +20,11 @@ MonoBehaviour:
   region: Nearest
   logType: 1
   edgeEventsConfig:
-    latencyThresholdTriggerMs: 120
+    latencyThresholdTriggerMs: 50
     latencyTestPort: 0
+    newFindCloudletEventTriggers: 050000000000000001000000020000000300000004000000
+    autoMigration: 1
+    performanceSwitchMargin: 0.05
     latencyConfig:
       updatePattern: 0
       updateIntervalSeconds: 30
@@ -30,4 +33,3 @@ MonoBehaviour:
       updatePattern: 0
       updateIntervalSeconds: 30
       maxNumberOfUpdates: 0
-    newFindCloudletEventTriggers: 0000000001000000020000000300000004000000

--- a/Runtime/Scripts/EdgeEventsConfig.cs
+++ b/Runtime/Scripts/EdgeEventsConfig.cs
@@ -38,21 +38,10 @@ namespace MobiledgeX
         "\nUse 0 to select a random port")]
     public int latencyTestPort;
     /// <summary>
-    /// Config for latency updates
-    /// </summary>
-    [Tooltip("Config for latency updates")]
-    public UpdateConfig latencyConfig;
-    /// <summary>
-    /// Config for location updates
-    /// </summary>
-    [Tooltip("Config for location updates")]
-    public UpdateConfig locationConfig;
-    /// <summary>
     /// List of triggers that will trigger a new find cloudlet.
     /// </summary>
     [Tooltip("List of triggers that will trigger a new find cloudlet.")]
     public List<FindCloudletEventTrigger> newFindCloudletEventTriggers;
-
     /// <summary>
     /// Allow MobiledgeX EdgeEvents to automatically stop the current EdgeEvents connection and start a new EdgeEvents connection to receive events from the new cloudlet
     /// </summary>
@@ -63,6 +52,16 @@ namespace MobiledgeX
     /// </summary>
     [Tooltip("Average performance must be by better by this latency margin (0 to 1.0f) before notifying of switch.")]
     public float performanceSwitchMargin = 0.05f;
+    /// <summary>
+    /// Config for latency updates
+    /// </summary>
+    [Tooltip("Config for latency updates")]
+    public UpdateConfig latencyConfig;
+    /// <summary>
+    /// Config for location updates
+    /// </summary>
+    [Tooltip("Config for location updates")]
+    public UpdateConfig locationConfig;
   }
 
 

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -79,10 +79,10 @@ public class ExampleRest : MonoBehaviour
 
     private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
     {
-        print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+        print("NewFindCloudlet triggered status is " + status.status + ", Trigger" + fcEvent.trigger);
         if(fcEvent.newCloudlet != null)
         {
-            print("New Cloudlet FQDN: "+fcEvent.newCloudlet.Fqdn);
+            print("New Cloudlet FQDN: " + fcEvent.newCloudlet.Fqdn);
         }
     }
 

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -80,6 +80,10 @@ public class ExampleRest : MonoBehaviour
     private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
     {
         print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+        if(fcEvent.newCloudlet != null)
+        {
+            print("New Cloudlet FQDN: "+fcEvent.newCloudlet.Fqdn);
+        }
     }
 
     IEnumerator RestExample(string url)

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -79,7 +79,7 @@ public class ExampleRest : MonoBehaviour
 
     private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
     {
-        throw new NotImplementedException();
+        print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
     }
 
     IEnumerator RestExample(string url)

--- a/Runtime/Scripts/ExampleUDP.cs
+++ b/Runtime/Scripts/ExampleUDP.cs
@@ -43,6 +43,10 @@ public class ExampleUDP : MonoBehaviour
     private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
     {
         print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+        if(fcEvent.newCloudlet != null)
+        {
+            print("New Cloudlet FQDN: "+fcEvent.newCloudlet.Fqdn);
+        }
     }
     void Update()
     {

--- a/Runtime/Scripts/ExampleUDP.cs
+++ b/Runtime/Scripts/ExampleUDP.cs
@@ -42,10 +42,10 @@ public class ExampleUDP : MonoBehaviour
     
     private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
     {
-        print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+        print("NewFindCloudlet triggered status is " + status.status + ", Trigger" + fcEvent.trigger);
         if(fcEvent.newCloudlet != null)
         {
-            print("New Cloudlet FQDN: "+fcEvent.newCloudlet.Fqdn);
+            print("New Cloudlet FQDN: " + fcEvent.newCloudlet.Fqdn);
         }
     }
     void Update()

--- a/Runtime/Scripts/ExampleUDP.cs
+++ b/Runtime/Scripts/ExampleUDP.cs
@@ -20,7 +20,8 @@ public class ExampleUDP : MonoBehaviour
 
     async void GetEdgeConnection()
     {
-        mxi = new MobiledgeXIntegration();
+        mxi = new MobiledgeXIntegration(FindObjectOfType<PersistentConnection>());
+        mxi.NewFindCloudletHandler += HandleFindCloudlet;
         await mxi.RegisterAndFindCloudlet();
         udpSendPort = mxi.GetAppPort(LProto.Udp).PublicPort;
         udpHost = mxi.GetHost();
@@ -38,7 +39,11 @@ public class ExampleUDP : MonoBehaviour
         //byte[] messageBinary = Encoding.ASCII.GetBytes(message);
         //udpClient.Send(messageBinary);
     }
-
+    
+    private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
+    {
+        print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+    }
     void Update()
     {
         if (udpClient == null)

--- a/Runtime/Scripts/ExampleWebSocket.cs
+++ b/Runtime/Scripts/ExampleWebSocket.cs
@@ -58,6 +58,10 @@ using DistributedMatchEngine;
         private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
         {
             print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+            if(fcEvent.newCloudlet != null)
+            {
+                print("New Cloudlet FQDN: "+fcEvent.newCloudlet.Fqdn);
+            }
         }
 
         // Dequeue WebSocket Messages every frame (if there is any)

--- a/Runtime/Scripts/ExampleWebSocket.cs
+++ b/Runtime/Scripts/ExampleWebSocket.cs
@@ -22,7 +22,8 @@ using DistributedMatchEngine;
 
         async void GetEdgeConnection()
         {
-            mxi = new MobiledgeXIntegration();
+            mxi = new MobiledgeXIntegration(FindObjectOfType<PersistentConnection>());
+            mxi.NewFindCloudletHandler += HandleFindCloudlet;
             try
             {
                 await mxi.RegisterAndFindCloudlet();
@@ -54,7 +55,10 @@ using DistributedMatchEngine;
             await wsClient.Connect(uri);
         }
 
-
+        private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
+        {
+            print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+        }
 
         // Dequeue WebSocket Messages every frame (if there is any)
         private void Update()

--- a/Runtime/Scripts/ExampleWebSocket.cs
+++ b/Runtime/Scripts/ExampleWebSocket.cs
@@ -57,10 +57,10 @@ using DistributedMatchEngine;
 
         private void HandleFindCloudlet(EdgeEventsStatus status, FindCloudletEvent fcEvent)
         {
-            print("NewFindCloudlet triggered status is  " + status.status + ", Trigger" + fcEvent.trigger);
+            print("NewFindCloudlet triggered status is " + status.status + ", Trigger" + fcEvent.trigger);
             if(fcEvent.newCloudlet != null)
             {
-                print("New Cloudlet FQDN: "+fcEvent.newCloudlet.Fqdn);
+                print("New Cloudlet FQDN: " + fcEvent.newCloudlet.Fqdn);
             }
         }
 


### PR DESCRIPTION
1. DefaultConfig added to MobiledgeXSettings.Asset [Confluence Page](https://mobiledgex.atlassian.net/wiki/spaces/SWDEV/pages/2099511297/Default+EdgeEvents+Config+for+SDKs)
2. Change EdgeEvents variables order to appear neatly in the Inpsector. (Screenshot Attached)
3. Changing PersistentConnection.startStreamingEvents encapsulation from public to internal (not intended for developer to use)
4. Changing PersistentConnection.StartEdgeEvents()  encapsulation from private to public (for the developer to use in the case where UpdatePattern is OnTrigger)
5. Change  PersistentConnection  Location encapsulation from private to public for Testing and For Developers who have their own LocationHandler.

<img width="506" alt="Screen Shot 2021-06-22 at 4 53 17 PM" src="https://user-images.githubusercontent.com/24863504/123014136-68a44900-d37a-11eb-8dd9-ebe8b002ad61.png">

