### PR TITLE
Edge config errors

### DIFF
--- a/Runtime/Scripts/EdgeEventsConfig.cs
+++ b/Runtime/Scripts/EdgeEventsConfig.cs
@@ -139,12 +139,12 @@ namespace MobiledgeX
     /// <summary>
     /// empty if the status = success
     /// </summary>
-    public string error_msg;
+    public EdgeEventsError error;
 
-    public EdgeEventsStatus(Status status, string error_msg = "")
+    public EdgeEventsStatus(Status status, EdgeEventsError error = EdgeEventsError.None)
     {
       this.status = status;
-      this.error_msg = error_msg;
+      this.error = error;
     }
   }
 
@@ -152,5 +152,21 @@ namespace MobiledgeX
   {
     success,
     error
+  }
+
+  public enum EdgeEventsError
+  {
+    MissingSessionCookie,
+    MissingEdgeEventsCookie,
+    UnableToGetLastLocation,
+    InvalidEdgeEventsSetup,
+    InvalidLatencyThreshold,
+    InvalidPerformanceSwitchMargin,
+    InvalidUpdateInterval,
+    PortDoesNotExist,
+    EventTriggeredButCurrentCloudletIsBest,
+    EventTriggeredButFindCloudletError,
+    EventError,
+    None
   }
 }

--- a/Runtime/Scripts/EdgeEventsManager.cs
+++ b/Runtime/Scripts/EdgeEventsManager.cs
@@ -273,7 +273,7 @@ namespace MobiledgeX
     IEnumerator StartEdgeEventsLocation(EdgeEventsConnection connection)
     {
       yield return StartCoroutine(UpdateLocation());
-      connection.PostLocationUpdate(location).ConfigureAwait(false).GetAwaiter().GetResult();
+      connection.PostLocationUpdate(location).ConfigureAwait(false);
       switch (config.locationConfig.updatePattern)
       {
         case UpdatePattern.OnStart:
@@ -294,13 +294,13 @@ namespace MobiledgeX
       bool requestSent;
       if (hasTCPPorts)
       {
-        requestSent = connection.TestConnectAndPostLatencyUpdate(host, (uint)config.latencyTestPort, location).ConfigureAwait(false).GetAwaiter().GetResult();
-        Logger.Log("TestConnectAndPostLatencyUpdate : " + requestSent);
+        connection.TestConnectAndPostLatencyUpdate(host, (uint)config.latencyTestPort, location).ConfigureAwait(false);
+        Logger.Log("TestConnectAndPostLatencyUpdate : fired " );
       }
       else
       {
-        requestSent = connection.TestPingAndPostLatencyUpdate(host, location).ConfigureAwait(false).GetAwaiter().GetResult();
-        Logger.Log("TestPingAndPostLatencyUpdate : " + requestSent);
+         connection.TestPingAndPostLatencyUpdate(host, location).ConfigureAwait(false);
+         Logger.Log("TestConnectAndPostLatencyUpdate : fired ");
       }
 
       switch (config.latencyConfig.updatePattern)
@@ -537,7 +537,6 @@ namespace MobiledgeX
       latencyUpdatesRunning = false;
       locationUpdatesCounter = 0;
       locationUpdatesRunning = false;
-      location = null;
     }
 
     void PropagateSuccess(FindCloudletEventTrigger trigger, FindCloudletReply newCloudlet)
@@ -695,6 +694,8 @@ namespace MobiledgeX
       Logger.Log("FindCloudletPerformanceMode Request: " + fcReq.ToString());
       try
       {
+        Logger.Log("FindCloudletPerformanceMode HostOverride: " + hostOverride);
+        Logger.Log("FindCloudletPerformanceMode portOverride: " + portOverride);
         fcReply = await matchingEngine.FindCloudletPerformanceMode(hostOverride, portOverride, fcReq);
       }
       catch (Exception fce)

--- a/Runtime/Scripts/ExampleRest.cs
+++ b/Runtime/Scripts/ExampleRest.cs
@@ -86,7 +86,7 @@ public class ExampleRest : MonoBehaviour
         }
         if (edgeEventstatus.status == Status.error)
         {
-            print("Error received: " + edgeEventstatus.error_msg);
+            print("Error received: " + edgeEventstatus.error);
         }
     }
 

--- a/Runtime/Scripts/ExampleUDP.cs
+++ b/Runtime/Scripts/ExampleUDP.cs
@@ -49,7 +49,7 @@ public class ExampleUDP : MonoBehaviour
         }
         if (edgeEventstatus.status == Status.error)
         {
-            print("Error received: " + edgeEventstatus.error_msg);
+            print("Error received: " + edgeEventstatus.error);
         }
     }
     void Update()

--- a/Runtime/Scripts/ExampleWebSocket.cs
+++ b/Runtime/Scripts/ExampleWebSocket.cs
@@ -64,7 +64,7 @@ using DistributedMatchEngine;
             }
             if (edgeEventstatus.status == Status.error)
             {
-                print("Error received: " + edgeEventstatus.error_msg);
+                print("Error received: " + edgeEventstatus.error);
             }
         }
 

--- a/Runtime/Scripts/MobiledgeXIntegration.cs
+++ b/Runtime/Scripts/MobiledgeXIntegration.cs
@@ -93,7 +93,7 @@ namespace MobiledgeX
         /// Use this action to get notified when a connection upgrade is available
         /// </summary>
         public Action<EdgeEventsStatus, FindCloudletEvent> NewFindCloudletHandler;
-        string region
+        internal string region
         {
             get
             {


### PR DESCRIPTION
1. Stick to EdgeEventErrors similar to iOS and Android SDK as much as possible. 
2. Add Connection Details class for handling HostOverride, PostOverride and useSelectedRegionInProduction boolean.
3. Start and Close the EdgeEventsConnection properly according to the new C# updates.