### PR TITLE
LatencyUpdate Interval Update

### DIFF
--- a/Runtime/Scripts/EdgeEventsManager.cs
+++ b/Runtime/Scripts/EdgeEventsManager.cs
@@ -155,9 +155,9 @@ namespace MobiledgeX
             Debug.LogError("latencyConfig.maxNumberOfUpdates must be >= 0");
             return EdgeEventsError.InvalidEdgeEventsSetup;
           }
-          if (config.latencyConfig.updateIntervalSeconds < 30)
+          if (config.latencyConfig.updateIntervalSeconds <= 0)
           {
-            Debug.LogError("latencyConfig.updateIntervalSeconds must be > 30");
+            Debug.LogError("latencyConfig.updateIntervalSeconds must be > 0");
             return EdgeEventsError.InvalidUpdateInterval;
           }
         }


### PR DESCRIPTION
Setting latency update interval minimum to 0 to be in sync with other SDKs.

Fix for
https://mobiledgex.atlassian.net/browse/EDGECLOUD-5731