### PR TITLE
Use native methods for device static info

### DIFF
--- a/Runtime/Scripts/CarrierInfoIntegration.cs
+++ b/Runtime/Scripts/CarrierInfoIntegration.cs
@@ -441,6 +441,26 @@ namespace MobiledgeX
         return "";
       }
     }
+
+    public string GetManufacturer()
+    {
+      AndroidJavaObject telephonyManager = GetTelephonyManager();
+      if (telephonyManager == null)
+      {
+        Logger.Log("No TelephonyManager!");
+        return "";
+      }
+      AndroidJavaClass versionCodesClass = new AndroidJavaClass("android.os.Build$VERSION_CODES");
+      int versionCode = PlatformIntegrationUtil.GetStatic<int>(versionCodesClass, "Q");
+      if (sdkVersion > versionCode)
+      {
+        string mc = PlatformIntegrationUtil.Call<string>(telephonyManager, "getManufacturerCode");
+
+        return mc;
+      }
+      return "";
+    }
+
 #elif UNITY_IOS
 
     // Sets iOS platform specific internal callbacks (reference counted objects), etc.

--- a/Runtime/Scripts/DeviceInfoIntegration.cs
+++ b/Runtime/Scripts/DeviceInfoIntegration.cs
@@ -17,6 +17,7 @@
 
 using DistributedMatchEngine;
 using UnityEngine;
+using System.Runtime.InteropServices;
 
 namespace MobiledgeX
 {
@@ -46,17 +47,24 @@ namespace MobiledgeX
       return deviceInfoDynamic;
     }
 
+#if UNITY_ANDROID
     public DeviceInfoStatic GetDeviceInfoStatic()
     {
+      string deviceModel = "Android";
+      string deviceOS = "Android";
+      if (overrideCarrierInfo == null)
+      {
+        CarrierInfoClass carrierInfo = new CarrierInfoClass();
+        deviceModel += carrierInfo.GetManufacturer();
+        deviceOS += carrierInfo.getAndroidSDKVers(); 
+      }
       DeviceInfoStatic deviceInfoStatic = new DeviceInfoStatic()
       {
-        DeviceModel = SystemInfo.deviceModel,
-        DeviceOs = SystemInfo.operatingSystem
+        DeviceModel = deviceModel,
+        DeviceOs = deviceOS
       };
       return deviceInfoStatic;
     }
-
-#if UNITY_ANDROID
 
     public bool IsPingSupported()
     {
@@ -65,13 +73,40 @@ namespace MobiledgeX
 
 #elif UNITY_IOS
 
+    [DllImport("__Internal")]
+    private static extern string _getDeviceModel();
+
+    [DllImport("__Internal")]
+    private static extern string _getOperatingSystem();
+
+    public DeviceInfoStatic GetDeviceInfoStatic()
+    {
+      string deviceModel = _getDeviceModel();
+      string deviceOS = _getOperatingSystem();
+
+      DeviceInfoStatic deviceInfoStatic = new DeviceInfoStatic()
+      {
+        DeviceModel = deviceModel,
+        DeviceOs = deviceOS
+      };
+      return deviceInfoStatic;
+    }
+
     public bool IsPingSupported()
     {
       return false;
     }
 
 #else // Unsupported platform.
-
+    public DeviceInfoStatic GetDeviceInfoStatic()
+    {
+      DeviceInfoStatic deviceInfoStatic = new DeviceInfoStatic()
+      {
+        DeviceModel = "UnityUnsupportedDeviceModel",
+        DeviceOs = "UnityUnsupportedDeviceOS"
+      };
+      return deviceInfoStatic;
+    }
     public bool IsPingSupported()
     {
       return true;

--- a/Runtime/Scripts/EdgeEventsManager.cs
+++ b/Runtime/Scripts/EdgeEventsManager.cs
@@ -213,7 +213,8 @@ namespace MobiledgeX
       }
       managerConnectionDetails.matchingEngine.EdgeEventsReceiver += HandleReceivedEvents;
       DeviceInfoDynamic deviceInfoDynamic = GetDynamicInfo(managerConnectionDetails.matchingEngine);
-      bool connectionOpened = managerConnectionDetails.matchingEngine.EdgeEventsConnection.Open(deviceInfoDynamic: deviceInfoDynamic);
+      DeviceInfoStatic deviceInfoStatic = GetStaticInfo(managerConnectionDetails.matchingEngine);
+      bool connectionOpened = managerConnectionDetails.matchingEngine.EdgeEventsConnection.Open(deviceInfoDynamic: deviceInfoDynamic, deviceInfoStatic: deviceInfoStatic);
       if (!connectionOpened)
       {
         Debug.LogError("Failed to OpenEdgeEventsConnection, StoppingEdgeEvents updates");
@@ -776,6 +777,26 @@ namespace MobiledgeX
         deviceInfoDynamic.CarrierName = "";
       }
       return deviceInfoDynamic;
+    }
+
+    public static DeviceInfoStatic GetStaticInfo(MatchingEngine matchingEngine)
+    {
+      DeviceInfoStatic deviceInfoStatic;
+      if (Application.platform == RuntimePlatform.Android)
+      {
+        deviceInfoStatic = Task.Run(() =>
+        {
+          AndroidJNI.AttachCurrentThread();
+          DeviceInfoStatic result = matchingEngine.GetDeviceInfoStatic();
+          AndroidJNI.DetachCurrentThread();
+          return result;
+        }).Result;
+      }
+      else
+      {
+        deviceInfoStatic = matchingEngine.GetDeviceInfoStatic();
+      }
+      return deviceInfoStatic;
     }
 
     // This callback is emitted from a ThreadPoolWorker


### PR DESCRIPTION
For acquiring device static info we used [ UnityEngine.SystemInfo](https://docs.unity3d.com/ScriptReference/SystemInfo.html) class, Upon excessive testing this class is not as reliable (sometimes it doesn't return a value and doesn't throw any exceptions).

I will be reverting to the native (Swift and Java) methods for acquiring device os and device model in DeviceInfoIntegration.cs