### PR TITLE
Use Abort only for Disposing web socket object

### DIFF
--- a/Runtime/Scripts/MobiledgeXWebSocketClient.cs
+++ b/Runtime/Scripts/MobiledgeXWebSocketClient.cs
@@ -241,7 +241,6 @@ namespace MobiledgeX
       if (ws != null)
       {
         ws.Abort();
-        ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Dispose", tokenSource.Token).ConfigureAwait(false).GetAwaiter().GetResult();
         ws = null;
       }
     }


### PR DESCRIPTION
After Abort the token has been already disposed, this results in ObjectDisposedException.