### PR TITLE
Auto update for docs

### DIFF
--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out Docs branch
         uses: actions/checkout@v2
         with:
-           ref: docs-config
+           ref: docs
         
       - name: Check out the SDK master branch (REST)
         uses: actions/checkout@v2

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -29,6 +29,7 @@ jobs:
           sudo rm -rf ./sdk
           sudo mv docs/html/* docs/
           sudo rm -rf docs/html
+          sudo cp ./config/tab_b.png ./docs/tab_b.png 
         shell: bash
 
       - name: Commit Doxygen Updates

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -2,7 +2,7 @@
    
 name: MobiledgeX Unity Docs Update
 
-on: [release]
+on: [push]
 
 jobs:
   build:
@@ -12,14 +12,12 @@ jobs:
         uses: actions/checkout@v2
         with:
            ref: docs-config
-           token: ${ secrets.GITHUB_TOKEN )
         
       - name: Check out the SDK master branch (REST)
         uses: actions/checkout@v2
         with:
            ref: master
            path: ./sdk
-           token: ${ secrets.GITHUB_TOKEN )
 
       - name: Update Docs
         uses: mattnotmitt/doxygen-action@v1.9.2

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -23,7 +23,14 @@ jobs:
         uses: mattnotmitt/doxygen-action@v1.9.2
         with:  
           doxyfile-path: './config/Doxyfile'
-  
+
+      - name: Clean before commit
+        run: |
+          sudo rm -rf ./sdk
+          sudo mv docs/html/* docs/
+          sudo rm -rf docs/html
+        shell: bash
+
       - name: Commit Doxygen Updates
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -1,0 +1,34 @@
+
+   
+name: MobiledgeX Unity Docs Update
+
+on: [release]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Docs branch
+        uses: actions/checkout@v2
+        with:
+           ref: docs-config
+           token: ${ secrets.GITHUB_TOKEN )
+        
+      - name: Check out the SDK master branch (REST)
+        uses: actions/checkout@v2
+        with:
+           ref: master
+           path: ./sdk
+           token: ${ secrets.GITHUB_TOKEN )
+
+      - name: Update Docs
+        uses: mattnotmitt/doxygen-action@v1.9.2
+        with:  
+          doxyfile-path: './config/Doxyfile'
+  
+      - name: Commit Doxygen Updates
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+            commit_message: Docs Automated Updates
+            branch: docs
+            push_options: '--force'

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -37,5 +37,4 @@ jobs:
             commit_message: Docs Automated Updates
             branch: docs
             push_options: '--force'
-            add_options: '-u'
             skip_checkout: true

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -2,7 +2,7 @@
    
 name: MobiledgeX Unity Docs Update
 
-on: [push]
+on: [release]
 
 jobs:
   build:

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -37,3 +37,4 @@ jobs:
             commit_message: Docs Automated Updates
             branch: docs
             push_options: '--force'
+            add_options: '-u'

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -38,3 +38,4 @@ jobs:
             branch: docs
             push_options: '--force'
             add_options: '-u'
+            skip_checkout: true


### PR DESCRIPTION
Update Unity Docs on release, the GitHub action does the following:
1. Checks out the docs branch and then the SDK (master branch)
2. Runs Doxygen for updating the docs update.
>  the Doxyfile has references to the scripts through ./sdk/Runtime/Scripts
3. Cleans the docs branch and adds an automatic commit to the docs branch.


Once there is a new push to the docs branch, GitHub pages initialize a new build and deploy action

Docs link: 
https://mobiledgex.github.io/edge-cloud-sdk-unity
The tested action example:
 (on push for testing) https://github.com/mobiledgex/edge-cloud-sdk-unity/actions/runs/2020445379
The Github pages deployment action example:
https://github.com/mobiledgex/edge-cloud-sdk-unity/actions/runs/2020446705